### PR TITLE
Fix Windows CRLF/encoding issues in all remote Linux shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,30 @@
-# Shell integration scripts are embedded into remote SSH bootstraps.
-# Force LF so Windows checkouts / builds never bake CRLF into remote bash.
-assets/shell/** text eol=lf
+# Force LF for sources and anything that can run on remote Linux.
+# Windows autocrlf otherwise embeds CR into multi-line Rust string literals
+# and shell assets, which breaks remote bash/BusyBox (`$'\r': command not found`).
+* text=auto eol=lf
+
+*.rs text eol=lf
 *.sh text eol=lf
 *.fish text eol=lf
+*.toml text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.md text eol=lf
+*.json text eol=lf
+*.txt text eol=lf
+*.desktop text eol=lf
+*.svg text eol=lf
+*.plist text eol=lf
+*.webmanifest text eol=lf
+*.gitignore text eol=lf
+*.gitattributes text eol=lf
+LICENSE text eol=lf
+
+# Binaries — never touch line endings
+*.png binary
+*.ico binary
+*.icns binary
+*.ttf binary
+*.otf binary
+*.woff binary
+*.woff2 binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Shell integration scripts are embedded into remote SSH bootstraps.
+# Force LF so Windows checkouts / builds never bake CRLF into remote bash.
+assets/shell/** text eol=lf
+*.sh text eol=lf
+*.fish text eol=lf

--- a/assets/fonts/README.md
+++ b/assets/fonts/README.md
@@ -1,4 +1,4 @@
-﻿# Embedded fonts
+# Embedded fonts
 
 | File | Source | License | When embedded |
 |------|--------|---------|---------------|

--- a/crates/app-ui/src/panels/routes.rs
+++ b/crates/app-ui/src/panels/routes.rs
@@ -832,4 +832,18 @@ __VSTERM_RULES__
         assert!(p.rules.is_empty());
         assert_eq!(p.ipv4.len(), 1);
     }
+
+    #[test]
+    fn remote_routes_cmd_is_posix_safe() {
+        assert!(
+            !REMOTE_ROUTES_CMD.contains('\r'),
+            "REMOTE_ROUTES_CMD must not contain CR (Windows CRLF breaks remote sh)"
+        );
+        assert!(
+            REMOTE_ROUTES_CMD.is_ascii(),
+            "REMOTE_ROUTES_CMD must stay ASCII for remote BusyBox/sh"
+        );
+        assert!(REMOTE_ROUTES_CMD.contains("__VSTERM_ROUTES4__"));
+        assert!(REMOTE_ROUTES_CMD.contains("export LC_ALL=C"));
+    }
 }

--- a/crates/app-ui/src/remote_host.rs
+++ b/crates/app-ui/src/remote_host.rs
@@ -43,8 +43,8 @@ for f in /etc/openwrt_release /rom/etc/openwrt_release; do
   echo OPENWRT=1
   grep -E '^(DISTRIB_ID|DISTRIB_DESCRIPTION|DISTRIB_RELEASE)=' "$f" 2>/dev/null || true
 done
-# Asuswrt-Merlin / 官改 / Koolshare 梅林改版：通常无标准 os-release。
-# 社区判定：uname -o 含 Merlin、/koolshare、或 nvram + productid/buildno。
+# Asuswrt-Merlin / Koolshare forks often lack a standard os-release.
+# Heuristics: uname -o contains Merlin, /koolshare present, or nvram productid/buildno.
 case "`uname -o 2>/dev/null`" in *[Mm]erlin*) echo MERLIN=1 ;; esac
 [ -d /koolshare ] && echo MERLIN=1
 [ -d /jffs/koolshare ] && echo MERLIN=1
@@ -1044,5 +1044,19 @@ VSTERM_END
             "PRETTY_NAME=\"openEuler 22.03\"",
         ];
         assert_eq!(parse_osrel_section(&lines).as_deref(), Some("openeuler"));
+    }
+
+    #[test]
+    fn metrics_cmd_is_posix_safe() {
+        assert!(
+            !METRICS_CMD.contains('\r'),
+            "METRICS_CMD must not contain CR (Windows CRLF breaks remote sh)"
+        );
+        assert!(
+            METRICS_CMD.is_ascii(),
+            "METRICS_CMD must stay ASCII so LC_ALL=C remotes never see multibyte comments"
+        );
+        assert!(METRICS_CMD.contains("VSTERM_BEGIN"));
+        assert!(METRICS_CMD.contains("export LC_ALL=C"));
     }
 }

--- a/crates/connection-mgr/src/lib.rs
+++ b/crates/connection-mgr/src/lib.rs
@@ -5,6 +5,7 @@ mod backend;
 mod error;
 mod known_hosts;
 mod manager;
+mod posix_text;
 mod process;
 mod remote_exec;
 mod remote_fs;

--- a/crates/connection-mgr/src/manager.rs
+++ b/crates/connection-mgr/src/manager.rs
@@ -1,4 +1,4 @@
-﻿use crate::error::ConnError;
+use crate::error::ConnError;
 use crate::remote_exec::RemoteSession;
 use crate::russh_backend::RusshBackend;
 use crate::ssh_io::SshIoSession;

--- a/crates/connection-mgr/src/posix_text.rs
+++ b/crates/connection-mgr/src/posix_text.rs
@@ -1,0 +1,21 @@
+//! Helpers for text that must stay POSIX-safe on remote Linux hosts.
+//!
+//! Windows checkouts with `core.autocrlf` can bake CR into Rust string literals
+//! and embedded assets. Remote `/bin/sh` / bash then fail with `$'\r'` errors.
+
+/// Strip CR so remote shells never see Windows CRLF line endings.
+pub(crate) fn normalize_unix_newlines(value: &str) -> String {
+    value.replace('\r', "")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_crlf_and_lone_cr() {
+        assert_eq!(normalize_unix_newlines("a\r\nb\r\nc\n"), "a\nb\nc\n");
+        assert_eq!(normalize_unix_newlines("do\r\n"), "do\n");
+        assert_eq!(normalize_unix_newlines("alone\r"), "alone");
+    }
+}

--- a/crates/connection-mgr/src/russh_backend.rs
+++ b/crates/connection-mgr/src/russh_backend.rs
@@ -946,8 +946,26 @@ async fn open_raw_sftp(
 }
 
 fn wrap_sh_c(script: &str) -> String {
-    format!(
-        "sh -s <<'VSTERM_EOF'\n{}\nVSTERM_EOF",
-        script.trim()
-    )
+    // Host metrics / routes scripts are multi-line Rust string literals. On a
+    // Windows checkout with autocrlf those literals can contain `\r`, which
+    // breaks remote BusyBox/bash the same way shell-integration did.
+    let script = crate::posix_text::normalize_unix_newlines(script.trim());
+    format!("sh -s <<'VSTERM_EOF'\n{script}\nVSTERM_EOF")
+}
+
+#[cfg(test)]
+mod wrap_sh_tests {
+    use super::wrap_sh_c;
+
+    #[test]
+    fn wrap_strips_crlf_from_remote_scripts() {
+        let out = wrap_sh_c("export LC_ALL=C\r\necho hi\r\ndo\r\n");
+        assert!(
+            !out.contains('\r'),
+            "wrapped remote script must not contain CR"
+        );
+        assert!(out.contains("export LC_ALL=C\necho hi\ndo"));
+        assert!(out.starts_with("sh -s <<'VSTERM_EOF'\n"));
+        assert!(out.ends_with("\nVSTERM_EOF"));
+    }
 }

--- a/crates/connection-mgr/src/shell_integration.rs
+++ b/crates/connection-mgr/src/shell_integration.rs
@@ -17,12 +17,15 @@ pub(crate) fn remote_bootstrap_command() -> String {
 }
 
 fn bootstrap_script(nonce: &str) -> String {
-    let posix = shell_single_quote(POSIX_INTEGRATION);
-    let fish = shell_single_quote(FISH_INTEGRATION);
+    // Windows checkouts / builds may embed CRLF via autocrlf. Remote POSIX shells
+    // treat `\r` as syntax (`do\r`, `$'\r': command not found`), so always emit LF.
+    let posix = shell_single_quote(&normalize_unix_newlines(POSIX_INTEGRATION));
+    let fish = shell_single_quote(&normalize_unix_newlines(FISH_INTEGRATION));
     let nonce = shell_single_quote(nonce);
 
-    format!(
-        r#"umask 077
+    normalize_unix_newlines(
+        &format!(
+            r#"umask 077
 _vsterm_shell=${{SHELL:-/bin/sh}}
 _vsterm_name=`basename "$_vsterm_shell" 2>/dev/null || echo sh`
 _vsterm_tmp=`mktemp -d "${{TMPDIR:-/tmp}}/vsterm-shell.XXXXXXXX" 2>/dev/null` || {{
@@ -83,7 +86,13 @@ _vsterm_cleanup
 trap - EXIT HUP INT TERM
 exit "$_vsterm_status"
 "#
+        ),
     )
+}
+
+/// Strip CR so remote `/bin/sh` / bash never see Windows CRLF line endings.
+fn normalize_unix_newlines(value: &str) -> String {
+    value.replace('\r', "")
 }
 
 fn shell_single_quote(value: &str) -> String {
@@ -109,5 +118,24 @@ mod tests {
         assert!(command.contains("fish)"));
         assert!(!command.contains(".bashrc\" >>"));
         assert!(!command.contains(".zshrc\" >>"));
+    }
+
+    #[test]
+    fn bootstrap_emits_unix_newlines_only() {
+        let command = remote_bootstrap_command();
+        assert!(
+            !command.contains('\r'),
+            "remote bootstrap must not contain CR (Windows CRLF breaks bash on Linux)"
+        );
+        assert!(command.contains('\n'));
+        assert!(command.contains("for __vsterm_rc in"));
+        assert!(!command.contains("do\r"));
+    }
+
+    #[test]
+    fn normalize_unix_newlines_strips_cr() {
+        assert_eq!(normalize_unix_newlines("a\r\nb\r\nc\n"), "a\nb\nc\n");
+        assert_eq!(normalize_unix_newlines("do\r\n"), "do\n");
+        assert_eq!(normalize_unix_newlines("alone\r"), "alone");
     }
 }

--- a/crates/connection-mgr/src/shell_integration.rs
+++ b/crates/connection-mgr/src/shell_integration.rs
@@ -19,6 +19,8 @@ pub(crate) fn remote_bootstrap_command() -> String {
 fn bootstrap_script(nonce: &str) -> String {
     // Windows checkouts / builds may embed CRLF via autocrlf. Remote POSIX shells
     // treat `\r` as syntax (`do\r`, `$'\r': command not found`), so always emit LF.
+    use crate::posix_text::normalize_unix_newlines;
+
     let posix = shell_single_quote(&normalize_unix_newlines(POSIX_INTEGRATION));
     let fish = shell_single_quote(&normalize_unix_newlines(FISH_INTEGRATION));
     let nonce = shell_single_quote(nonce);
@@ -90,11 +92,6 @@ exit "$_vsterm_status"
     )
 }
 
-/// Strip CR so remote `/bin/sh` / bash never see Windows CRLF line endings.
-fn normalize_unix_newlines(value: &str) -> String {
-    value.replace('\r', "")
-}
-
 fn shell_single_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
@@ -130,12 +127,5 @@ mod tests {
         assert!(command.contains('\n'));
         assert!(command.contains("for __vsterm_rc in"));
         assert!(!command.contains("do\r"));
-    }
-
-    #[test]
-    fn normalize_unix_newlines_strips_cr() {
-        assert_eq!(normalize_unix_newlines("a\r\nb\r\nc\n"), "a\nb\nc\n");
-        assert_eq!(normalize_unix_newlines("do\r\n"), "do\n");
-        assert_eq!(normalize_unix_newlines("alone\r"), "alone");
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Connecting from a Windows build to Debian failed after login with:

```text
bash: $'\r': command not found
bash: .../vsterm.sh: line 18: syntax error near unexpected token `$'do\r''
```

Windows checkouts/builds with `core.autocrlf` can bake CRLF into embedded shell assets and **multi-line Rust string literals**. Those `\r` characters then reach remote Linux `/bin/sh` / bash / BusyBox.

## Audit (Win10 client → Linux servers)

| Path | Risk | Fix |
|------|------|-----|
| Shell integration bootstrap + `vsterm.sh` / `vsterm.fish` | High — confirmed user failure | Strip CR before SSH remote command |
| `wrap_sh_c` (host metrics + routes) | High — same CRLF path via `run_command` | Strip CR in the central wrapper |
| `METRICS_CMD` Chinese comments under `LC_ALL=C` | Medium — non-ASCII in remote script | Replaced with ASCII English comments |
| UTF-8 BOM in `manager.rs`, `fonts/README.md` | Low — source hygiene | BOM removed |
| `.gitattributes` incomplete | Root cause on Windows checkouts | Force LF for sources; mark binaries |

Remote script entry points covered:

- SSH shell-integration bootstrap
- Host monitor (`METRICS_CMD` → `run_command` → `wrap_sh_c`)
- Routes panel (`REMOTE_ROUTES_CMD` → `run_command` → `wrap_sh_c`)

New-file shebangs in the file browser already use explicit `\n` single-line literals (no CRLF risk).

## Fix

- Shared `posix_text::normalize_unix_newlines`
- Normalize in shell-integration bootstrap **and** `wrap_sh_c`
- ASCII-only remote scripts + stronger `.gitattributes`
- Regression tests for bootstrap, `wrap_sh_c`, and remote-script hygiene

## Test plan

- [x] `cargo test -p connection-mgr --lib`
- [ ] Rebuild Windows client and reconnect to Debian bash (login + shell integration)
- [ ] Confirm host monitor / routes still populate on Linux (BusyBox OpenWrt optional)
- [ ] Confirm no `$'\r'` / `do\r` errors after login

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9e2800f-61d1-4baa-a3f3-c15665d58d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9e2800f-61d1-4baa-a3f3-c15665d58d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

