### PR TITLE
Reduce RSS via GPU/scrollback; keep Win/macOS system fonts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5894,6 +5894,7 @@ dependencies = [
  "chrono",
  "parking_lot",
  "portable-pty",
+ "sysinfo",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/assets/fonts/README.md
+++ b/assets/fonts/README.md
@@ -3,7 +3,12 @@
 | File | Source | License | When embedded |
 |------|--------|---------|---------------|
 | JetBrainsMono-Regular.ttf | https://github.com/JetBrains/JetBrainsMono | SIL OFL 1.1 | All platforms (terminal) |
-| NotoSansSC-Light.otf | https://github.com/notofonts/noto-cjk (`Sans/SubsetOTF/SC`) | SIL OFL 1.1 | **Linux only** (UI CJK fallback) |
+| NotoSansSC-Light.otf | https://github.com/notofonts/noto-cjk (`Sans/SubsetOTF/SC`) | SIL OFL 1.1 | All platforms when system CJK is missing or too large |
 
-On Windows / macOS the UI uses system CJK fonts (YaHei Light / PingFang SC, …).
+UI CJK policy (RSS-aware):
+
+- Prefer a **compact** system face when the file is ≤ the embedded subset (~8 MB).
+- Otherwise use embedded Noto Sans SC Light instead of keeping YaHei / PingFang / full Noto CJK TTCs (often 11–40 MB) resident in the process heap.
+- Never keep both a large system TTC and the embed at once.
+
 Terminal uses **JetBrains Mono Regular** on every platform.

--- a/assets/fonts/README.md
+++ b/assets/fonts/README.md
@@ -3,12 +3,8 @@
 | File | Source | License | When embedded |
 |------|--------|---------|---------------|
 | JetBrainsMono-Regular.ttf | https://github.com/JetBrains/JetBrainsMono | SIL OFL 1.1 | All platforms (terminal) |
-| NotoSansSC-Light.otf | https://github.com/notofonts/noto-cjk (`Sans/SubsetOTF/SC`) | SIL OFL 1.1 | All platforms when system CJK is missing or too large |
+| NotoSansSC-Light.otf | https://github.com/notofonts/noto-cjk (`Sans/SubsetOTF/SC`) | SIL OFL 1.1 | **Linux only** (UI CJK fallback) |
 
-UI CJK policy (RSS-aware):
-
-- Prefer a **compact** system face when the file is ≤ the embedded subset (~8 MB).
-- Otherwise use embedded Noto Sans SC Light instead of keeping YaHei / PingFang / full Noto CJK TTCs (often 11–40 MB) resident in the process heap.
-- Never keep both a large system TTC and the embed at once.
-
+On Windows / macOS the UI uses system CJK fonts (YaHei Light / PingFang SC, …).
+On Linux, prefer system Noto CJK when present; otherwise use the embedded subset.
 Terminal uses **JetBrains Mono Regular** on every platform.

--- a/crates/app-ui/src/fonts.rs
+++ b/crates/app-ui/src/fonts.rs
@@ -1,14 +1,15 @@
-//! Cross-platform UI fonts: OS native CJK on Windows/macOS; embed only on Linux.
+//! Cross-platform UI fonts: prefer compact CJK sources to keep RSS down.
 //!
-//! | Platform | UI proportional                         | Terminal mono        |
-//! |----------|-----------------------------------------|----------------------|
-//! | Windows  | Microsoft YaHei Light (`msyhl.ttc`)     | JetBrains Mono       |
-//! | macOS    | PingFang SC / Heiti SC Light            | JetBrains Mono       |
-//! | Linux    | System Noto CJK when present, else embed| JetBrains Mono       |
+//! | Platform | UI proportional                                      | Terminal mono  |
+//! |----------|------------------------------------------------------|----------------|
+//! | Windows  | Compact system CJK if small enough, else embedded    | JetBrains Mono |
+//! | macOS    | Compact system CJK if small enough, else embedded    | JetBrains Mono |
+//! | Linux    | System Noto CJK when compact, else embedded          | JetBrains Mono |
 //!
-//! Noto Sans SC Light is embedded **only on Linux** so Windows/macOS builds stay small.
-//! Loading system fonts for local rendering (not redistributing them) matches normal
-//! desktop-app practice.
+//! Large system TTCs (YaHei / PingFang / Noto CJK collections, often 11–40 MB)
+//! used to be `fs::read` wholesale into the process heap. egui needs the bytes
+//! resident, so we cap system font loads and fall back to the ~8 MB embedded
+//! Noto Sans SC Light subset instead of keeping a 20 MB+ TTC in RAM.
 
 use egui::{FontData, FontDefinitions, FontFamily, FontId, TextStyle};
 use std::path::{Path, PathBuf};
@@ -17,14 +18,19 @@ use std::sync::Arc;
 const JETBRAINS_MONO_REGULAR: &[u8] =
     include_bytes!("../../../assets/fonts/JetBrainsMono-Regular.ttf");
 
-#[cfg(target_os = "linux")]
+/// Compact SC subset (~8 MB). Used on every platform when the OS CJK file is
+/// missing or too large to keep resident for the whole process lifetime.
 const NOTO_SANS_SC_LIGHT: &[u8] =
     include_bytes!("../../../assets/fonts/NotoSansSC-Light.otf");
 
 const FAMILY_UI: &str = "VsTermUI";
 const FAMILY_MONO: &str = "JetBrainsMono";
-#[cfg(target_os = "linux")]
 const FAMILY_FALLBACK_CJK: &str = "NotoSansSC-Light";
+
+/// Skip system font files larger than the embedded subset. Loading YaHei /
+/// PingFang TTCs (often 11–40 MB) into `FontData` is the main controllable RSS
+/// spike on Windows/macOS cold start.
+const MAX_SYSTEM_UI_FONT_BYTES: u64 = NOTO_SANS_SC_LIGHT.len() as u64;
 
 pub fn install(ctx: &egui::Context) {
     let mut fonts = FontDefinitions::default();
@@ -34,52 +40,38 @@ pub fn install(ctx: &egui::Context) {
         Arc::new(FontData::from_static(JETBRAINS_MONO_REGULAR)),
     );
 
-    #[cfg(target_os = "linux")]
-    {
-        fonts.font_data.insert(
-            FAMILY_FALLBACK_CJK.to_owned(),
-            Arc::new(FontData::from_static(NOTO_SANS_SC_LIGHT)),
-        );
-    }
-
     let default_proportional = fonts
         .families
         .get(&FontFamily::Proportional)
         .cloned()
         .unwrap_or_default();
 
-    let (ui_source, ui_family) = match load_platform_ui_font() {
+    let (ui_source, ui_family, register_embedded_fallback) = match load_platform_ui_font() {
         Some((label, data)) => {
             fonts
                 .font_data
                 .insert(FAMILY_UI.to_owned(), Arc::new(data));
-            (label, Some(FAMILY_UI.to_owned()))
+            // System face already covers CJK — do not also keep the 8 MB embed.
+            (label, Some(FAMILY_UI.to_owned()), false)
         }
-        None => {
-            #[cfg(target_os = "linux")]
-            {
-                (
-                    "embedded Noto Sans SC Light".into(),
-                    Some(FAMILY_FALLBACK_CJK.to_owned()),
-                )
-            }
-            #[cfg(not(target_os = "linux"))]
-            {
-                ("egui default (no system CJK font found)".into(), None)
-            }
-        }
+        None => (
+            "embedded Noto Sans SC Light".into(),
+            Some(FAMILY_FALLBACK_CJK.to_owned()),
+            true,
+        ),
     };
+
+    if register_embedded_fallback {
+        fonts.font_data.insert(
+            FAMILY_FALLBACK_CJK.to_owned(),
+            Arc::new(FontData::from_static(NOTO_SANS_SC_LIGHT)),
+        );
+    }
 
     if let Some(ref ui) = ui_family {
         // Keep egui defaults behind the UI font so rare symbols (menu ▸ / emoji)
         // still resolve instead of rendering as `?`.
         let mut proportional = vec![ui.clone()];
-        #[cfg(target_os = "linux")]
-        {
-            if ui.as_str() != FAMILY_FALLBACK_CJK {
-                proportional.push(FAMILY_FALLBACK_CJK.to_owned());
-            }
-        }
         for name in &default_proportional {
             if !proportional.iter().any(|n| n == name) {
                 proportional.push(name.clone());
@@ -94,12 +86,6 @@ pub fn install(ctx: &egui::Context) {
     if let Some(ref ui) = ui_family {
         mono.push(ui.clone());
     }
-    #[cfg(target_os = "linux")]
-    {
-        if ui_family.as_deref() != Some(FAMILY_FALLBACK_CJK) {
-            mono.push(FAMILY_FALLBACK_CJK.to_owned());
-        }
-    }
     if ui_family.is_none() {
         // Still cover CJK (where possible) via egui's default proportional stack.
         mono.extend(default_proportional);
@@ -111,13 +97,15 @@ pub fn install(ctx: &egui::Context) {
     ctx.set_fonts(fonts);
     apply_text_styles(ctx);
 
-    #[cfg(target_os = "linux")]
     tracing::info!(
-        "fonts: UI={ui_source}; mono=JetBrains Mono; CJK fallback=Noto Sans SC Light ({} KB); icons=Lucide",
+        "fonts: UI={ui_source}; mono=JetBrains Mono; CJK={} ({} KB); icons=Lucide",
+        if register_embedded_fallback {
+            "embedded Noto Sans SC Light"
+        } else {
+            "system (compact)"
+        },
         NOTO_SANS_SC_LIGHT.len() / 1024
     );
-    #[cfg(not(target_os = "linux"))]
-    tracing::info!("fonts: UI={ui_source}; mono=JetBrains Mono; CJK=system only; icons=Lucide");
 }
 
 fn register_lucide_fonts(fonts: &mut FontDefinitions) {
@@ -182,6 +170,8 @@ fn load_windows_ui_font() -> Option<(String, FontData)> {
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from(r"C:\Windows"));
     let fonts_dir = windir.join("Fonts");
+    // Prefer light faces, but only if the file stays under the RSS budget.
+    // Typical `msyhl.ttc` / `msyh.ttc` are 11–21 MB and will be skipped.
     let candidates: &[(&str, u32, &str)] = &[
         ("msyhl.ttc", 0, "Microsoft YaHei Light"),
         ("msyhl.ttc", 1, "Microsoft YaHei UI Light"),
@@ -238,16 +228,22 @@ fn load_macos_ui_font() -> Option<(String, FontData)> {
 
 #[cfg(target_os = "linux")]
 fn load_linux_ui_font() -> Option<(String, FontData)> {
+    // Prefer single-language OTF subsets over multi-script TTC collections.
     let candidates: &[(&str, u32, &str)] = &[
-        (
-            "/usr/share/fonts/opentype/noto/NotoSansCJK-Light.ttc",
-            0,
-            "Noto Sans CJK Light",
-        ),
         (
             "/usr/share/fonts/opentype/noto/NotoSansCJKsc-Light.otf",
             0,
             "Noto Sans CJK SC Light",
+        ),
+        (
+            "/usr/share/fonts/truetype/noto/NotoSansSC-Light.otf",
+            0,
+            "Noto Sans SC Light",
+        ),
+        (
+            "/usr/share/fonts/opentype/noto/NotoSansCJK-Light.ttc",
+            0,
+            "Noto Sans CJK Light",
         ),
         (
             "/usr/share/fonts/google-noto-cjk/NotoSansCJK-Light.ttc",
@@ -258,11 +254,6 @@ fn load_linux_ui_font() -> Option<(String, FontData)> {
             "/usr/share/fonts/noto-cjk/NotoSansCJK-Light.ttc",
             0,
             "Noto Sans CJK Light",
-        ),
-        (
-            "/usr/share/fonts/truetype/noto/NotoSansSC-Light.otf",
-            0,
-            "Noto Sans SC Light",
         ),
     ];
     for (path, index, label) in candidates {
@@ -293,6 +284,20 @@ fn read_font_file(path: &Path, index: u32) -> Option<FontData> {
     if !path.is_file() {
         return None;
     }
+    let meta = std::fs::metadata(path).ok()?;
+    let len = meta.len();
+    if len < 64 {
+        return None;
+    }
+    if len > MAX_SYSTEM_UI_FONT_BYTES {
+        tracing::info!(
+            "fonts: skip {} ({} KB) — exceeds {} KB RSS budget; using embedded subset",
+            path.display(),
+            len / 1024,
+            MAX_SYSTEM_UI_FONT_BYTES / 1024
+        );
+        return None;
+    }
     let bytes = std::fs::read(path).ok()?;
     if bytes.len() < 64 {
         return None;
@@ -300,4 +305,25 @@ fn read_font_file(path: &Path, index: u32) -> Option<FontData> {
     let mut data = FontData::from_owned(bytes);
     data.index = index;
     Some(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_cjk_subset_is_compact() {
+        // Guard against accidentally shipping a full multi-script CJK TTC.
+        assert!(
+            NOTO_SANS_SC_LIGHT.len() <= 9 * 1024 * 1024,
+            "embedded CJK subset unexpectedly large: {} bytes",
+            NOTO_SANS_SC_LIGHT.len()
+        );
+        assert!(NOTO_SANS_SC_LIGHT.len() > 1024 * 1024);
+    }
+
+    #[test]
+    fn system_font_budget_matches_embedded_subset() {
+        assert_eq!(MAX_SYSTEM_UI_FONT_BYTES, NOTO_SANS_SC_LIGHT.len() as u64);
+    }
 }

--- a/crates/app-ui/src/fonts.rs
+++ b/crates/app-ui/src/fonts.rs
@@ -1,15 +1,14 @@
-//! Cross-platform UI fonts: prefer compact CJK sources to keep RSS down.
+//! Cross-platform UI fonts: OS native CJK on Windows/macOS; embed only on Linux.
 //!
-//! | Platform | UI proportional                                      | Terminal mono  |
-//! |----------|------------------------------------------------------|----------------|
-//! | Windows  | Compact system CJK if small enough, else embedded    | JetBrains Mono |
-//! | macOS    | Compact system CJK if small enough, else embedded    | JetBrains Mono |
-//! | Linux    | System Noto CJK when compact, else embedded          | JetBrains Mono |
+//! | Platform | UI proportional                         | Terminal mono        |
+//! |----------|-----------------------------------------|----------------------|
+//! | Windows  | Microsoft YaHei Light (`msyhl.ttc`)     | JetBrains Mono       |
+//! | macOS    | PingFang SC / Heiti SC Light            | JetBrains Mono       |
+//! | Linux    | System Noto CJK when present, else embed| JetBrains Mono       |
 //!
-//! Large system TTCs (YaHei / PingFang / Noto CJK collections, often 11–40 MB)
-//! used to be `fs::read` wholesale into the process heap. egui needs the bytes
-//! resident, so we cap system font loads and fall back to the ~8 MB embedded
-//! Noto Sans SC Light subset instead of keeping a 20 MB+ TTC in RAM.
+//! Noto Sans SC Light is embedded **only on Linux** so Windows/macOS builds stay small.
+//! Loading system fonts for local rendering (not redistributing them) matches normal
+//! desktop-app practice.
 
 use egui::{FontData, FontDefinitions, FontFamily, FontId, TextStyle};
 use std::path::{Path, PathBuf};
@@ -18,19 +17,14 @@ use std::sync::Arc;
 const JETBRAINS_MONO_REGULAR: &[u8] =
     include_bytes!("../../../assets/fonts/JetBrainsMono-Regular.ttf");
 
-/// Compact SC subset (~8 MB). Used on every platform when the OS CJK file is
-/// missing or too large to keep resident for the whole process lifetime.
+#[cfg(target_os = "linux")]
 const NOTO_SANS_SC_LIGHT: &[u8] =
     include_bytes!("../../../assets/fonts/NotoSansSC-Light.otf");
 
 const FAMILY_UI: &str = "VsTermUI";
 const FAMILY_MONO: &str = "JetBrainsMono";
+#[cfg(target_os = "linux")]
 const FAMILY_FALLBACK_CJK: &str = "NotoSansSC-Light";
-
-/// Skip system font files larger than the embedded subset. Loading YaHei /
-/// PingFang TTCs (often 11–40 MB) into `FontData` is the main controllable RSS
-/// spike on Windows/macOS cold start.
-const MAX_SYSTEM_UI_FONT_BYTES: u64 = NOTO_SANS_SC_LIGHT.len() as u64;
 
 pub fn install(ctx: &egui::Context) {
     let mut fonts = FontDefinitions::default();
@@ -46,27 +40,31 @@ pub fn install(ctx: &egui::Context) {
         .cloned()
         .unwrap_or_default();
 
-    let (ui_source, ui_family, register_embedded_fallback) = match load_platform_ui_font() {
+    let (ui_source, ui_family) = match load_platform_ui_font() {
         Some((label, data)) => {
             fonts
                 .font_data
                 .insert(FAMILY_UI.to_owned(), Arc::new(data));
-            // System face already covers CJK — do not also keep the 8 MB embed.
-            (label, Some(FAMILY_UI.to_owned()), false)
+            (label, Some(FAMILY_UI.to_owned()))
         }
-        None => (
-            "embedded Noto Sans SC Light".into(),
-            Some(FAMILY_FALLBACK_CJK.to_owned()),
-            true,
-        ),
+        None => {
+            #[cfg(target_os = "linux")]
+            {
+                fonts.font_data.insert(
+                    FAMILY_FALLBACK_CJK.to_owned(),
+                    Arc::new(FontData::from_static(NOTO_SANS_SC_LIGHT)),
+                );
+                (
+                    "embedded Noto Sans SC Light".into(),
+                    Some(FAMILY_FALLBACK_CJK.to_owned()),
+                )
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                ("egui default (no system CJK font found)".into(), None)
+            }
+        }
     };
-
-    if register_embedded_fallback {
-        fonts.font_data.insert(
-            FAMILY_FALLBACK_CJK.to_owned(),
-            Arc::new(FontData::from_static(NOTO_SANS_SC_LIGHT)),
-        );
-    }
 
     if let Some(ref ui) = ui_family {
         // Keep egui defaults behind the UI font so rare symbols (menu ▸ / emoji)
@@ -97,15 +95,17 @@ pub fn install(ctx: &egui::Context) {
     ctx.set_fonts(fonts);
     apply_text_styles(ctx);
 
+    #[cfg(target_os = "linux")]
     tracing::info!(
-        "fonts: UI={ui_source}; mono=JetBrains Mono; CJK={} ({} KB); icons=Lucide",
-        if register_embedded_fallback {
-            "embedded Noto Sans SC Light"
+        "fonts: UI={ui_source}; mono=JetBrains Mono; CJK={}; icons=Lucide",
+        if ui_family.as_deref() == Some(FAMILY_FALLBACK_CJK) {
+            format!("embedded Noto Sans SC Light ({} KB)", NOTO_SANS_SC_LIGHT.len() / 1024)
         } else {
-            "system (compact)"
-        },
-        NOTO_SANS_SC_LIGHT.len() / 1024
+            "system only".into()
+        }
     );
+    #[cfg(not(target_os = "linux"))]
+    tracing::info!("fonts: UI={ui_source}; mono=JetBrains Mono; CJK=system only; icons=Lucide");
 }
 
 fn register_lucide_fonts(fonts: &mut FontDefinitions) {
@@ -170,8 +170,6 @@ fn load_windows_ui_font() -> Option<(String, FontData)> {
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from(r"C:\Windows"));
     let fonts_dir = windir.join("Fonts");
-    // Prefer light faces, but only if the file stays under the RSS budget.
-    // Typical `msyhl.ttc` / `msyh.ttc` are 11–21 MB and will be skipped.
     let candidates: &[(&str, u32, &str)] = &[
         ("msyhl.ttc", 0, "Microsoft YaHei Light"),
         ("msyhl.ttc", 1, "Microsoft YaHei UI Light"),
@@ -228,22 +226,16 @@ fn load_macos_ui_font() -> Option<(String, FontData)> {
 
 #[cfg(target_os = "linux")]
 fn load_linux_ui_font() -> Option<(String, FontData)> {
-    // Prefer single-language OTF subsets over multi-script TTC collections.
     let candidates: &[(&str, u32, &str)] = &[
-        (
-            "/usr/share/fonts/opentype/noto/NotoSansCJKsc-Light.otf",
-            0,
-            "Noto Sans CJK SC Light",
-        ),
-        (
-            "/usr/share/fonts/truetype/noto/NotoSansSC-Light.otf",
-            0,
-            "Noto Sans SC Light",
-        ),
         (
             "/usr/share/fonts/opentype/noto/NotoSansCJK-Light.ttc",
             0,
             "Noto Sans CJK Light",
+        ),
+        (
+            "/usr/share/fonts/opentype/noto/NotoSansCJKsc-Light.otf",
+            0,
+            "Noto Sans CJK SC Light",
         ),
         (
             "/usr/share/fonts/google-noto-cjk/NotoSansCJK-Light.ttc",
@@ -254,6 +246,11 @@ fn load_linux_ui_font() -> Option<(String, FontData)> {
             "/usr/share/fonts/noto-cjk/NotoSansCJK-Light.ttc",
             0,
             "Noto Sans CJK Light",
+        ),
+        (
+            "/usr/share/fonts/truetype/noto/NotoSansSC-Light.otf",
+            0,
+            "Noto Sans SC Light",
         ),
     ];
     for (path, index, label) in candidates {
@@ -284,20 +281,6 @@ fn read_font_file(path: &Path, index: u32) -> Option<FontData> {
     if !path.is_file() {
         return None;
     }
-    let meta = std::fs::metadata(path).ok()?;
-    let len = meta.len();
-    if len < 64 {
-        return None;
-    }
-    if len > MAX_SYSTEM_UI_FONT_BYTES {
-        tracing::info!(
-            "fonts: skip {} ({} KB) — exceeds {} KB RSS budget; using embedded subset",
-            path.display(),
-            len / 1024,
-            MAX_SYSTEM_UI_FONT_BYTES / 1024
-        );
-        return None;
-    }
     let bytes = std::fs::read(path).ok()?;
     if bytes.len() < 64 {
         return None;
@@ -305,25 +288,4 @@ fn read_font_file(path: &Path, index: u32) -> Option<FontData> {
     let mut data = FontData::from_owned(bytes);
     data.index = index;
     Some(data)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn embedded_cjk_subset_is_compact() {
-        // Guard against accidentally shipping a full multi-script CJK TTC.
-        assert!(
-            NOTO_SANS_SC_LIGHT.len() <= 9 * 1024 * 1024,
-            "embedded CJK subset unexpectedly large: {} bytes",
-            NOTO_SANS_SC_LIGHT.len()
-        );
-        assert!(NOTO_SANS_SC_LIGHT.len() > 1024 * 1024);
-    }
-
-    #[test]
-    fn system_font_budget_matches_embedded_subset() {
-        assert_eq!(MAX_SYSTEM_UI_FONT_BYTES, NOTO_SANS_SC_LIGHT.len() as u64);
-    }
 }

--- a/crates/app-ui/src/fonts.rs
+++ b/crates/app-ui/src/fonts.rs
@@ -285,6 +285,12 @@ fn read_font_file(path: &Path, index: u32) -> Option<FontData> {
     if bytes.len() < 64 {
         return None;
     }
+    tracing::info!(
+        "fonts: loaded system face {} ({} KB, ttc_index={})",
+        path.display(),
+        bytes.len() / 1024,
+        index
+    );
     let mut data = FontData::from_owned(bytes);
     data.index = index;
     Some(data)

--- a/crates/app-ui/src/main.rs
+++ b/crates/app-ui/src/main.rs
@@ -75,6 +75,9 @@ fn main() -> Result<()> {
             // makes DX12 WARP busy-wait across several worker threads after a
             // restored window, so it is unsuitable for supported RDP/VM use.
             present_mode: wgpu::PresentMode::AutoNoVsync,
+            // One buffered frame is enough for a UI; default latency keeps more
+            // swapchain images resident and inflates working set.
+            desired_maximum_frame_latency: Some(1),
             ..Default::default()
         },
         ..Default::default()
@@ -118,7 +121,25 @@ fn preferred_backends() -> wgpu::Backends {
 fn wgpu_setup() -> eframe::egui_wgpu::WgpuSetupCreateNew {
     let mut setup = eframe::egui_wgpu::WgpuSetupCreateNew::default();
     setup.instance_descriptor.backends = preferred_backends();
-    setup.power_preference = wgpu::PowerPreference::HighPerformance;
+    // Prefer integrated GPU when available — discrete adapters often reserve
+    // far more driver/working-set memory for an egui UI than we need.
+    setup.power_preference = wgpu::PowerPreference::LowPower;
+    setup.device_descriptor = std::sync::Arc::new(|adapter| {
+        let base_limits = if adapter.get_info().backend == wgpu::Backend::Gl {
+            wgpu::Limits::downlevel_webgl2_defaults()
+        } else {
+            wgpu::Limits::default()
+        };
+        wgpu::DeviceDescriptor {
+            label: Some("egui wgpu device"),
+            required_features: wgpu::Features::default(),
+            required_limits: wgpu::Limits {
+                max_texture_dimension_2d: 8192,
+                ..base_limits
+            },
+            memory_hints: wgpu::MemoryHints::MemoryUsage,
+        }
+    });
     setup.native_adapter_selector = Some(std::sync::Arc::new(|adapters, surface| {
         if adapters.is_empty() {
             return Err(
@@ -134,15 +155,27 @@ fn wgpu_setup() -> eframe::egui_wgpu::WgpuSetupCreateNew {
                 info.device_type
             );
         }
-        let hardware = adapters.iter().find(|a| {
-            let ty = a.get_info().device_type;
-            matches!(
-                ty,
-                wgpu::DeviceType::DiscreteGpu | wgpu::DeviceType::IntegratedGpu
-            ) && surface_ok(a, surface)
-        });
-        if let Some(adapter) = hardware {
+        // Integrated first (lower RSS), then discrete — still skip CPU unless
+        // nothing else can present to the surface.
+        let pick = |ty: wgpu::DeviceType| {
+            adapters.iter().find(|a| {
+                a.get_info().device_type == ty && surface_ok(a, surface)
+            })
+        };
+        if let Some(adapter) = pick(wgpu::DeviceType::IntegratedGpu) {
             render_policy::set_software_renderer(false);
+            tracing::info!(
+                "wgpu selected integrated GPU: {}",
+                adapter.get_info().name
+            );
+            return Ok(adapter.clone());
+        }
+        if let Some(adapter) = pick(wgpu::DeviceType::DiscreteGpu) {
+            render_policy::set_software_renderer(false);
+            tracing::info!(
+                "wgpu selected discrete GPU: {}",
+                adapter.get_info().name
+            );
             return Ok(adapter.clone());
         }
         let any_non_cpu = adapters.iter().find(|a| {

--- a/crates/term-core/Cargo.toml
+++ b/crates/term-core/Cargo.toml
@@ -14,3 +14,4 @@ parking_lot = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 chrono = { workspace = true }
+sysinfo = { workspace = true }

--- a/crates/term-core/src/terminal.rs
+++ b/crates/term-core/src/terminal.rs
@@ -15,9 +15,47 @@ use crate::TermError;
 /// Invoked (possibly from a PTY reader thread) after the grid accepts new bytes.
 pub type OutputHook = Arc<dyn Fn() + Send + Sync>;
 
-/// Default scrollback depth. 10k lines of a wide grid can cost ~40–50 MB per
-/// busy session; 5k keeps useful history while roughly halving that ceiling.
-const SCROLLBACK_LINES: usize = 5_000;
+/// Start small for idle sessions; grow only when the user actually produces history.
+const SCROLLBACK_INITIAL: usize = 5_000;
+const SCROLLBACK_MID: usize = 10_000;
+const SCROLLBACK_MAX: usize = 20_000;
+/// First growth: once ~3k history lines exist, raise the cap to 10k.
+const SCROLLBACK_GROW_TO_MID_AT: usize = 3_000;
+
+/// Next scrollback cap for `used` history lines under the current `limit`.
+///
+/// - default 5 000
+/// - ≥ 3 000 lines → 10 000
+/// - ≥ 4/5 of current cap → 20 000
+fn next_scrollback_limit(used: usize, limit: usize) -> Option<usize> {
+    if limit < SCROLLBACK_MID && used >= SCROLLBACK_GROW_TO_MID_AT {
+        Some(SCROLLBACK_MID)
+    } else if limit < SCROLLBACK_MAX && used.saturating_mul(5) >= limit.saturating_mul(4) {
+        Some(SCROLLBACK_MAX)
+    } else {
+        None
+    }
+}
+
+fn maybe_grow_scrollback(state: &mut TermState) {
+    let used = state.term.history_size();
+    let Some(next) = next_scrollback_limit(used, state.scrollback_limit) else {
+        return;
+    };
+    if next <= state.scrollback_limit {
+        return;
+    }
+    let mut config = Config::default();
+    config.scrolling_history = next;
+    state.term.set_options(config);
+    tracing::debug!(
+        "terminal scrollback grew {} → {} (history_lines={})",
+        state.scrollback_limit,
+        next,
+        used
+    );
+    state.scrollback_limit = next;
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Rgb {
@@ -138,6 +176,8 @@ struct TermState {
     line_times: Vec<Option<NaiveTime>>,
     /// Cursor abs after the previous advance (for stamping line ranges).
     prev_cursor_abs: usize,
+    /// Current scrollback capacity (grows with output; see `maybe_grow_scrollback`).
+    scrollback_limit: usize,
 }
 
 impl TerminalHandle {
@@ -149,7 +189,7 @@ impl TerminalHandle {
             rows: rows_usize,
         };
         let mut config = Config::default();
-        config.scrolling_history = SCROLLBACK_LINES;
+        config.scrolling_history = SCROLLBACK_INITIAL;
         let term = Term::new(config, &size, VoidListener);
         Self {
             inner: Arc::new(Mutex::new(TermState {
@@ -164,6 +204,7 @@ impl TerminalHandle {
                 view_offset: 0,
                 line_times: Vec::new(),
                 prev_cursor_abs: 0,
+                scrollback_limit: SCROLLBACK_INITIAL,
             })),
             output_hook: Arc::new(Mutex::new(None)),
         }
@@ -296,6 +337,8 @@ impl TerminalHandle {
                     state.line_times.drain(0..dropped);
                 }
             }
+
+            maybe_grow_scrollback(&mut state);
 
             // Keep the open block's end at the current cursor (output growth).
             let abs = cursor_abs(&state.term, history_size);
@@ -734,6 +777,36 @@ fn indexed_to_rgb(idx: u8) -> Rgb {
             let v = 8 + 10 * (idx - 232);
             Rgb::new(v, v, v)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrollback_grows_at_three_thousand_then_four_fifths() {
+        assert_eq!(next_scrollback_limit(0, SCROLLBACK_INITIAL), None);
+        assert_eq!(next_scrollback_limit(2_999, SCROLLBACK_INITIAL), None);
+        assert_eq!(
+            next_scrollback_limit(3_000, SCROLLBACK_INITIAL),
+            Some(SCROLLBACK_MID)
+        );
+        assert_eq!(next_scrollback_limit(7_999, SCROLLBACK_MID), None);
+        assert_eq!(
+            next_scrollback_limit(8_000, SCROLLBACK_MID),
+            Some(SCROLLBACK_MAX)
+        );
+        assert_eq!(next_scrollback_limit(20_000, SCROLLBACK_MAX), None);
+    }
+
+    #[test]
+    fn scrollback_four_fifths_of_initial_still_goes_to_mid_first() {
+        // 4/5 of 5000 is 4000, but the 3000 threshold already raised us to mid.
+        assert_eq!(
+            next_scrollback_limit(4_000, SCROLLBACK_INITIAL),
+            Some(SCROLLBACK_MID)
+        );
     }
 }
 

--- a/crates/term-core/src/terminal.rs
+++ b/crates/term-core/src/terminal.rs
@@ -18,7 +18,8 @@ pub type OutputHook = Arc<dyn Fn() + Send + Sync>;
 /// Start small for idle sessions; grow only when the user actually produces history.
 const SCROLLBACK_INITIAL: usize = 5_000;
 const SCROLLBACK_MID: usize = 10_000;
-const SCROLLBACK_HIGH: usize = 50_000;
+/// After the first bump to 10k, raise the cap by this step until the hard max.
+const SCROLLBACK_STEP: usize = 10_000;
 /// Hard ceiling (aligned with Alacritty's documented max). Beyond this, oldest
 /// history is discarded (FIFO) — we never grow further.
 const SCROLLBACK_MAX: usize = 100_000;
@@ -32,20 +33,18 @@ const SCROLLBACK_MIN_FREE_BYTES: u64 = 256 * 1024 * 1024;
 ///
 /// - default 5 000
 /// - ≥ 3 000 lines → 10 000
-/// - ≥ 4/5 of current cap → 50 000, then 100 000 (hard max)
+/// - thereafter, when ≥ 4/5 full → +10 000 each time, up to 100 000
 fn next_scrollback_limit(used: usize, limit: usize) -> Option<usize> {
     if limit >= SCROLLBACK_MAX {
         return None;
     }
     if limit < SCROLLBACK_MID && used >= SCROLLBACK_GROW_TO_MID_AT {
-        Some(SCROLLBACK_MID)
-    } else if limit < SCROLLBACK_HIGH && used.saturating_mul(5) >= limit.saturating_mul(4) {
-        Some(SCROLLBACK_HIGH)
-    } else if used.saturating_mul(5) >= limit.saturating_mul(4) {
-        Some(SCROLLBACK_MAX)
-    } else {
-        None
+        return Some(SCROLLBACK_MID);
     }
+    if limit >= SCROLLBACK_MID && used.saturating_mul(5) >= limit.saturating_mul(4) {
+        return Some((limit + SCROLLBACK_STEP).min(SCROLLBACK_MAX));
+    }
+    None
 }
 
 fn memory_allows_scrollback_growth() -> bool {
@@ -820,23 +819,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn scrollback_grows_at_three_thousand_then_four_fifths() {
+    fn scrollback_grows_at_three_thousand_then_ten_k_steps() {
         assert_eq!(next_scrollback_limit(0, SCROLLBACK_INITIAL), None);
         assert_eq!(next_scrollback_limit(2_999, SCROLLBACK_INITIAL), None);
         assert_eq!(
             next_scrollback_limit(3_000, SCROLLBACK_INITIAL),
             Some(SCROLLBACK_MID)
         );
-        assert_eq!(next_scrollback_limit(7_999, SCROLLBACK_MID), None);
-        assert_eq!(
-            next_scrollback_limit(8_000, SCROLLBACK_MID),
-            Some(SCROLLBACK_HIGH)
-        );
-        assert_eq!(next_scrollback_limit(39_999, SCROLLBACK_HIGH), None);
-        assert_eq!(
-            next_scrollback_limit(40_000, SCROLLBACK_HIGH),
-            Some(SCROLLBACK_MAX)
-        );
+        // From 10k upward: +10k each time the buffer is ≥ 4/5 full.
+        assert_eq!(next_scrollback_limit(7_999, 10_000), None);
+        assert_eq!(next_scrollback_limit(8_000, 10_000), Some(20_000));
+        assert_eq!(next_scrollback_limit(16_000, 20_000), Some(30_000));
+        assert_eq!(next_scrollback_limit(40_000, 50_000), Some(60_000));
+        assert_eq!(next_scrollback_limit(72_000, 90_000), Some(100_000));
         // Hard max: never propose another growth step.
         assert_eq!(next_scrollback_limit(100_000, SCROLLBACK_MAX), None);
         assert_eq!(next_scrollback_limit(usize::MAX, SCROLLBACK_MAX), None);
@@ -852,11 +847,17 @@ mod tests {
     }
 
     #[test]
-    fn scrollback_hard_max_is_one_hundred_thousand() {
+    fn scrollback_steps_ten_k_up_to_one_hundred_k() {
+        assert_eq!(SCROLLBACK_STEP, 10_000);
         assert_eq!(SCROLLBACK_MAX, 100_000);
-        assert!(SCROLLBACK_INITIAL < SCROLLBACK_MID);
-        assert!(SCROLLBACK_MID < SCROLLBACK_HIGH);
-        assert!(SCROLLBACK_HIGH < SCROLLBACK_MAX);
+        let mut limit = SCROLLBACK_MID;
+        while limit < SCROLLBACK_MAX {
+            let used = (limit * 4).div_ceil(5);
+            let next = next_scrollback_limit(used, limit).expect("should grow");
+            assert_eq!(next, (limit + SCROLLBACK_STEP).min(SCROLLBACK_MAX));
+            limit = next;
+        }
+        assert_eq!(limit, SCROLLBACK_MAX);
     }
 }
 

--- a/crates/term-core/src/terminal.rs
+++ b/crates/term-core/src/terminal.rs
@@ -18,31 +18,59 @@ pub type OutputHook = Arc<dyn Fn() + Send + Sync>;
 /// Start small for idle sessions; grow only when the user actually produces history.
 const SCROLLBACK_INITIAL: usize = 5_000;
 const SCROLLBACK_MID: usize = 10_000;
+/// Hard ceiling. Beyond this, oldest history is discarded (FIFO) — we never grow further.
 const SCROLLBACK_MAX: usize = 20_000;
 /// First growth: once ~3k history lines exist, raise the cap to 10k.
 const SCROLLBACK_GROW_TO_MID_AT: usize = 3_000;
+/// Refuse to raise the cap when the host has less free RAM than this.
+/// Raising the cap itself is cheap; the reserve avoids thrashing as new lines allocate.
+const SCROLLBACK_MIN_FREE_BYTES: u64 = 256 * 1024 * 1024;
 
 /// Next scrollback cap for `used` history lines under the current `limit`.
 ///
 /// - default 5 000
 /// - ≥ 3 000 lines → 10 000
-/// - ≥ 4/5 of current cap → 20 000
+/// - ≥ 4/5 of current cap → 20 000 (hard max)
 fn next_scrollback_limit(used: usize, limit: usize) -> Option<usize> {
+    if limit >= SCROLLBACK_MAX {
+        return None;
+    }
     if limit < SCROLLBACK_MID && used >= SCROLLBACK_GROW_TO_MID_AT {
         Some(SCROLLBACK_MID)
-    } else if limit < SCROLLBACK_MAX && used.saturating_mul(5) >= limit.saturating_mul(4) {
+    } else if used.saturating_mul(5) >= limit.saturating_mul(4) {
         Some(SCROLLBACK_MAX)
     } else {
         None
     }
 }
 
+fn memory_allows_scrollback_growth() -> bool {
+    let mut sys = sysinfo::System::new();
+    sys.refresh_memory();
+    sys.available_memory() >= SCROLLBACK_MIN_FREE_BYTES
+}
+
 fn maybe_grow_scrollback(state: &mut TermState) {
+    if state.scrollback_limit >= SCROLLBACK_MAX || state.scrollback_grow_blocked {
+        // At hard max (or previously refused): alacritty drops oldest lines when full.
+        return;
+    }
     let used = state.term.history_size();
     let Some(next) = next_scrollback_limit(used, state.scrollback_limit) else {
         return;
     };
     if next <= state.scrollback_limit {
+        return;
+    }
+    if !memory_allows_scrollback_growth() {
+        // Keep the current cap. Once history fills it, alacritty discards the
+        // oldest lines — same outcome as hitting SCROLLBACK_MAX.
+        tracing::warn!(
+            "terminal scrollback growth skipped (need ≥{} MB free RAM); keeping {} lines, oldest history will be discarded when full",
+            SCROLLBACK_MIN_FREE_BYTES / (1024 * 1024),
+            state.scrollback_limit
+        );
+        state.scrollback_grow_blocked = true;
         return;
     }
     let mut config = Config::default();
@@ -178,6 +206,8 @@ struct TermState {
     prev_cursor_abs: usize,
     /// Current scrollback capacity (grows with output; see `maybe_grow_scrollback`).
     scrollback_limit: usize,
+    /// Set when a growth step was refused due to low free RAM (no further grow attempts).
+    scrollback_grow_blocked: bool,
 }
 
 impl TerminalHandle {
@@ -205,6 +235,7 @@ impl TerminalHandle {
                 line_times: Vec::new(),
                 prev_cursor_abs: 0,
                 scrollback_limit: SCROLLBACK_INITIAL,
+                scrollback_grow_blocked: false,
             })),
             output_hook: Arc::new(Mutex::new(None)),
         }
@@ -797,7 +828,9 @@ mod tests {
             next_scrollback_limit(8_000, SCROLLBACK_MID),
             Some(SCROLLBACK_MAX)
         );
+        // Hard max: never propose another growth step.
         assert_eq!(next_scrollback_limit(20_000, SCROLLBACK_MAX), None);
+        assert_eq!(next_scrollback_limit(usize::MAX, SCROLLBACK_MAX), None);
     }
 
     #[test]
@@ -807,6 +840,13 @@ mod tests {
             next_scrollback_limit(4_000, SCROLLBACK_INITIAL),
             Some(SCROLLBACK_MID)
         );
+    }
+
+    #[test]
+    fn scrollback_hard_max_is_twenty_thousand() {
+        assert_eq!(SCROLLBACK_MAX, 20_000);
+        assert!(SCROLLBACK_INITIAL < SCROLLBACK_MID);
+        assert!(SCROLLBACK_MID < SCROLLBACK_MAX);
     }
 }
 

--- a/crates/term-core/src/terminal.rs
+++ b/crates/term-core/src/terminal.rs
@@ -18,8 +18,10 @@ pub type OutputHook = Arc<dyn Fn() + Send + Sync>;
 /// Start small for idle sessions; grow only when the user actually produces history.
 const SCROLLBACK_INITIAL: usize = 5_000;
 const SCROLLBACK_MID: usize = 10_000;
-/// Hard ceiling. Beyond this, oldest history is discarded (FIFO) — we never grow further.
-const SCROLLBACK_MAX: usize = 20_000;
+const SCROLLBACK_HIGH: usize = 50_000;
+/// Hard ceiling (aligned with Alacritty's documented max). Beyond this, oldest
+/// history is discarded (FIFO) — we never grow further.
+const SCROLLBACK_MAX: usize = 100_000;
 /// First growth: once ~3k history lines exist, raise the cap to 10k.
 const SCROLLBACK_GROW_TO_MID_AT: usize = 3_000;
 /// Refuse to raise the cap when the host has less free RAM than this.
@@ -30,13 +32,15 @@ const SCROLLBACK_MIN_FREE_BYTES: u64 = 256 * 1024 * 1024;
 ///
 /// - default 5 000
 /// - ≥ 3 000 lines → 10 000
-/// - ≥ 4/5 of current cap → 20 000 (hard max)
+/// - ≥ 4/5 of current cap → 50 000, then 100 000 (hard max)
 fn next_scrollback_limit(used: usize, limit: usize) -> Option<usize> {
     if limit >= SCROLLBACK_MAX {
         return None;
     }
     if limit < SCROLLBACK_MID && used >= SCROLLBACK_GROW_TO_MID_AT {
         Some(SCROLLBACK_MID)
+    } else if limit < SCROLLBACK_HIGH && used.saturating_mul(5) >= limit.saturating_mul(4) {
+        Some(SCROLLBACK_HIGH)
     } else if used.saturating_mul(5) >= limit.saturating_mul(4) {
         Some(SCROLLBACK_MAX)
     } else {
@@ -826,10 +830,15 @@ mod tests {
         assert_eq!(next_scrollback_limit(7_999, SCROLLBACK_MID), None);
         assert_eq!(
             next_scrollback_limit(8_000, SCROLLBACK_MID),
+            Some(SCROLLBACK_HIGH)
+        );
+        assert_eq!(next_scrollback_limit(39_999, SCROLLBACK_HIGH), None);
+        assert_eq!(
+            next_scrollback_limit(40_000, SCROLLBACK_HIGH),
             Some(SCROLLBACK_MAX)
         );
         // Hard max: never propose another growth step.
-        assert_eq!(next_scrollback_limit(20_000, SCROLLBACK_MAX), None);
+        assert_eq!(next_scrollback_limit(100_000, SCROLLBACK_MAX), None);
         assert_eq!(next_scrollback_limit(usize::MAX, SCROLLBACK_MAX), None);
     }
 
@@ -843,10 +852,11 @@ mod tests {
     }
 
     #[test]
-    fn scrollback_hard_max_is_twenty_thousand() {
-        assert_eq!(SCROLLBACK_MAX, 20_000);
+    fn scrollback_hard_max_is_one_hundred_thousand() {
+        assert_eq!(SCROLLBACK_MAX, 100_000);
         assert!(SCROLLBACK_INITIAL < SCROLLBACK_MID);
-        assert!(SCROLLBACK_MID < SCROLLBACK_MAX);
+        assert!(SCROLLBACK_MID < SCROLLBACK_HIGH);
+        assert!(SCROLLBACK_HIGH < SCROLLBACK_MAX);
     }
 }
 

--- a/crates/term-core/src/terminal.rs
+++ b/crates/term-core/src/terminal.rs
@@ -15,7 +15,9 @@ use crate::TermError;
 /// Invoked (possibly from a PTY reader thread) after the grid accepts new bytes.
 pub type OutputHook = Arc<dyn Fn() + Send + Sync>;
 
-const SCROLLBACK_LINES: usize = 10_000;
+/// Default scrollback depth. 10k lines of a wide grid can cost ~40–50 MB per
+/// busy session; 5k keeps useful history while roughly halving that ceiling.
+const SCROLLBACK_LINES: usize = 5_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Rgb {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Dynamic scrollback policy

| Stage | Cap |
|-------|-----|
| New session | **5 000** |
| History ≥ 3 000 | **10 000** |
| Thereafter, history ≥ 4/5 of current | **+10 000** each time |
| **Hard max** | **100 000** |

Example path: `5k → 10k → 20k → 30k → … → 100k` (gradual memory growth).

### When we cannot grow

1. **Already at 100k** → discard oldest lines (FIFO)
2. **Free RAM &lt; 256MB** → refuse raise; same FIFO when full

## Other RSS work

- Prefer integrated GPU + `MemoryHints::MemoryUsage` + frame latency 1
- Font policy unchanged (system CJK on Win/mac; embed Linux-only)
- Startup font path/size log

## Test plan

- [x] `cargo test -p term-core scrollback`
- [ ] Long output across several 10k steps
- [ ] At hard max, oldest lines drop

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9e2800f-61d1-4baa-a3f3-c15665d58d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9e2800f-61d1-4baa-a3f3-c15665d58d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

