### PR TITLE
Fix ZMODEM dialog race/freeze and SSH memory on tab close

### DIFF
--- a/crates/app-ui/src/app.rs
+++ b/crates/app-ui/src/app.rs
@@ -1483,7 +1483,14 @@ impl eframe::App for VsTermApp {
                     .clicked()
                     {
                         if let Some(id) = self.connections.active_id() {
+                            let host_key = self.connections.remote_display_key(id);
+                            // Release metrics target before dropping the SSH Arc.
+                            self.remote_host.bind(None, None);
                             self.connections.close(id);
+                            if let Some(key) = host_key {
+                                bottom_panel::forget_saved_host(&mut self.bottom, &key);
+                                self.remote_host.forget_host(&key);
+                            }
                             self.sync_host_binding();
                             self.status = i18n::t("status.closed");
                         }
@@ -1565,8 +1572,9 @@ impl eframe::App for VsTermApp {
         });
 
         egui::TopBottomPanel::bottom("status_bar").show(ctx, |ui| {
+            let zmodem = self.connections.active_zmodem_status();
             let zmodem_busy = matches!(
-                self.connections.active_zmodem_status(),
+                zmodem,
                 Some(
                     ZmodemStatus::Receiving { .. }
                         | ZmodemStatus::Sending { .. }
@@ -1574,12 +1582,14 @@ impl eframe::App for VsTermApp {
                         | ZmodemStatus::AwaitingSaveAs { .. }
                 )
             );
+            let zmodem_progress = zmodem.as_ref().and_then(|s| s.progress_fraction());
             status_bar::show(
                 ui,
                 &self.status,
                 self.connections.list_meta().len(),
                 crate::render_policy::is_software_renderer(),
                 zmodem_busy,
+                zmodem_progress,
                 || {
                     let _ = self.connections.cancel_zmodem();
                 },
@@ -1726,15 +1736,20 @@ impl eframe::App for VsTermApp {
                                             self.main_tab = MainTab::Terminal;
                                         }
                                         Some(connection_list::ConnAction::Close(id)) => {
-                                            let host_key = self
-                                                .connections
-                                                .remote_display_key(id);
+                                            let host_key =
+                                                self.connections.remote_display_key(id);
+                                            // Drop metrics bind first so `RemoteSession`
+                                            // Arcs are not pinned while I/O is torn down.
+                                            if self.connections.active_id() == Some(id) {
+                                                self.remote_host.bind(None, None);
+                                            }
                                             self.connections.close(id);
                                             if let Some(key) = host_key {
                                                 bottom_panel::forget_saved_host(
                                                     &mut self.bottom,
                                                     &key,
                                                 );
+                                                self.remote_host.forget_host(&key);
                                             }
                                             self.sync_host_binding();
                                             self.status = i18n::t("status.closed");

--- a/crates/app-ui/src/panels/status_bar.rs
+++ b/crates/app-ui/src/panels/status_bar.rs
@@ -7,10 +7,24 @@ pub fn show(
     conn_count: usize,
     software_renderer: bool,
     zmodem_busy: bool,
+    zmodem_progress: Option<f32>,
     on_cancel_zmodem: impl FnOnce(),
 ) {
     ui.horizontal(|ui| {
         ui.label(status);
+        if let Some(frac) = zmodem_progress {
+            let bar = egui::ProgressBar::new(frac)
+                .desired_width(120.0)
+                .show_percentage();
+            ui.add(bar);
+        } else if zmodem_busy {
+            // Indeterminate-ish: thin busy bar while waiting on a dialog.
+            ui.add(
+                egui::ProgressBar::new(0.0)
+                    .desired_width(120.0)
+                    .animate(true),
+            );
+        }
         if zmodem_busy {
             if ui
                 .small_button(i18n::t("zmodem.cancel"))

--- a/crates/app-ui/src/remote_host.rs
+++ b/crates/app-ui/src/remote_host.rs
@@ -405,6 +405,22 @@ impl RemoteHostService {
             store_cache(&mut g, &key);
         }
     }
+
+    /// Drop cached metrics for a closed host tab so snapshots (and any
+    /// lingering `RemoteSession` clones via `target`) do not keep RSS around.
+    pub fn forget_host(&self, key: &str) {
+        let mut g = self.inner.lock();
+        g.cache.remove(key);
+        if g.target
+            .as_ref()
+            .is_some_and(|t| t.session.display_key() == key)
+        {
+            g.target = None;
+            g.snapshot = HostSnapshot::default();
+            g.selected_nic = None;
+            g.last_error = None;
+        }
+    }
 }
 
 impl Drop for RemoteHostService {
@@ -412,6 +428,9 @@ impl Drop for RemoteHostService {
         self.stop();
     }
 }
+
+/// Soft cap so many short-lived tabs cannot grow the metrics cache without bound.
+const MAX_HOST_CACHE: usize = 16;
 
 fn store_cache(g: &mut RemoteState, key: &str) {
     // Skip caching empty placeholders so a brief blank tab does not wipe a good view.
@@ -430,6 +449,22 @@ fn store_cache(g: &mut RemoteState, key: &str) {
             last_tick: g.last_tick,
         },
     );
+    while g.cache.len() > MAX_HOST_CACHE {
+        // Drop an entry that is not the live target (oldest insertion order is
+        // not tracked — remove an arbitrary non-active key).
+        let live = g.target.as_ref().map(|t| t.session.display_key());
+        let victim = g
+            .cache
+            .keys()
+            .find(|k| live.as_ref() != Some(k))
+            .cloned()
+            .or_else(|| g.cache.keys().next().cloned());
+        if let Some(k) = victim {
+            g.cache.remove(&k);
+        } else {
+            break;
+        }
+    }
 }
 
 fn poll_once(state: &Arc<Mutex<RemoteState>>) -> Result<HostSnapshot, String> {

--- a/crates/connection-mgr/src/manager.rs
+++ b/crates/connection-mgr/src/manager.rs
@@ -368,8 +368,15 @@ impl ConnectionManager {
                 *active = self.order.lock().last().copied();
             }
         }
-        drop(removed);
         self.bump();
+        // Drop SSH/PTY I/O off the UI thread. Synchronous drop joins reader
+        // threads and disconnects russh; doing that inline keeps RSS high and
+        // can hitch the frame where the tab was closed.
+        if let Some(conn) = removed {
+            std::thread::spawn(move || {
+                drop(conn);
+            });
+        }
     }
 
     pub fn close_all(&self) {

--- a/crates/connection-mgr/src/russh_backend.rs
+++ b/crates/connection-mgr/src/russh_backend.rs
@@ -17,7 +17,7 @@ use parking_lot::Mutex as ParkingMutex;
 use russh::client::{AuthResult, Handle, KeyboardInteractiveAuthResponse};
 use russh::keys::{load_secret_key, PrivateKeyWithHashAlg, PublicKey};
 use russh::MethodKind;
-use russh::{client, ChannelMsg};
+use russh::{client, ChannelMsg, Disconnect};
 use russh_sftp::protocol::FileAttributes;
 
 /// Cipher negotiation order. AES-256-GCM first so we use CPU AES instructions
@@ -609,6 +609,19 @@ impl Drop for RusshRemoteExec {
                 let _ = s.raw.close_session();
             }
         }
+        // Tear down the TCP/SSH session so channel windows and crypto state
+        // are not retained until process exit (Arc alone is not enough if the
+        // russh task outlives the UI drop path).
+        let session = Arc::clone(&self.session);
+        let host = self.host.clone();
+        let _ = runtime().block_on(async move {
+            if let Err(err) = session
+                .disconnect(Disconnect::ByApplication, "", "English")
+                .await
+            {
+                tracing::debug!("russh disconnect {host}: {err}");
+            }
+        });
     }
 }
 

--- a/crates/term-core/src/zmodem.rs
+++ b/crates/term-core/src/zmodem.rs
@@ -1,13 +1,14 @@
 //! ZMODEM (rz/sz) support over the interactive PTY/SSH shell channel.
 //!
 //! Remote `sz` → local receive (download). Remote `rz` → local send (upload).
-//! Binary frames are diverted away from the terminal grid while a transfer runs.
 //!
-//! I/O is caller-driven: protocol methods return bytes to write on the wire so
-//! the reader/UI never nest the ZMODEM mutex with the PTY writer mutex.
+//! **Dialog pause:** after the remote filename is known (`sz`) or ZRINIT is
+//! seen (`rz`), the protocol stalls until the UI confirms a path / file list.
+//! We do not ACK / send file data while a dialog is open — that avoids the
+//! "already finished before OK" race and the post-confirm freeze.
 
 use parking_lot::Mutex;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use zmodem2::{Action, Event, FileInfo, Position, Receiver, Sender};
@@ -15,29 +16,25 @@ use zmodem2::{Action, Event, FileInfo, Position, Receiver, Sender};
 /// Result of feeding remote bytes through the ZMODEM gate.
 #[derive(Debug, Default)]
 pub struct RxResult {
-    /// Bytes that should reach the terminal emulator (may be empty).
     pub to_terminal: Vec<u8>,
-    /// Protocol response bytes to write back on the PTY/SSH channel.
     pub to_wire: Vec<u8>,
 }
 
 #[derive(Debug, Clone)]
 pub enum ZmodemStatus {
     Idle,
-    /// Remote ran `sz` — waiting for the UI Save As dialog.
+    /// Remote `sz`: filename known, waiting for Save As.
     AwaitingSaveAs {
         suggested_name: String,
         total: Option<u64>,
     },
-    /// Saving the current `sz` file to the path chosen in Save As.
     Receiving {
         file_name: String,
         bytes: u64,
         total: Option<u64>,
     },
-    /// Remote ran `rz` — waiting for the UI to pick local file(s).
+    /// Remote `rz`: waiting for local file picker.
     AwaitingUpload,
-    /// Uploading local file(s) to remote `rz`.
     Sending {
         file_name: String,
         bytes: u64,
@@ -51,20 +48,34 @@ pub enum ZmodemStatus {
     },
 }
 
+impl ZmodemStatus {
+    /// Progress fraction in `0.0..=1.0` when total size is known.
+    pub fn progress_fraction(&self) -> Option<f32> {
+        match self {
+            Self::Receiving {
+                bytes, total: Some(t), ..
+            }
+            | Self::Sending {
+                bytes, total: Some(t), ..
+            } if *t > 0 => Some((*bytes as f32 / *t as f32).clamp(0.0, 1.0)),
+            Self::AwaitingSaveAs {
+                total: Some(t), ..
+            } if *t > 0 => Some(0.0),
+            _ => None,
+        }
+    }
+}
+
 struct RecvState {
     engine: Receiver,
     file: Option<File>,
-    /// Final destination after Save As (None while still on a temp file).
     path: Option<PathBuf>,
-    /// Scratch file used until the user confirms Save As.
-    temp_path: Option<PathBuf>,
     name: String,
     written: u64,
     total: Option<u64>,
     inbox: Vec<u8>,
+    /// True until Save As confirms a destination path.
     awaiting_save: bool,
-    /// True after `FileCompleted` for the current file (no more writes).
-    file_finished: bool,
 }
 
 struct SendState {
@@ -86,7 +97,6 @@ enum Stage {
     Send(SendState),
 }
 
-/// Per-connection ZMODEM divertor shared by the reader thread and UI.
 pub struct ZmodemBridge {
     inner: Mutex<Inner>,
 }
@@ -134,18 +144,17 @@ impl ZmodemBridge {
         }
     }
 
-    /// CAN sequence used to abort a transfer on the wire.
     pub fn cancel_bytes() -> &'static [u8] {
         &[0x18, 0x18, 0x18, 0x18, 0x18]
     }
 
-    /// Cancel any active transfer. Caller must write the returned wire bytes.
     pub fn cancel(&self) -> Vec<u8> {
         let mut g = self.inner.lock();
         if let Stage::Recv(recv) = &mut g.stage {
             drop(recv.file.take());
-            if let Some(temp) = recv.temp_path.take() {
-                let _ = fs::remove_file(temp);
+            // Remove a partial download if we already opened the Save As path.
+            if let Some(path) = recv.path.take() {
+                let _ = fs::remove_file(path);
             }
         }
         g.stage = Stage::Idle {
@@ -157,13 +166,14 @@ impl ZmodemBridge {
         Self::cancel_bytes().to_vec()
     }
 
-    /// Default folder suggested for the Save As dialog (Downloads when available).
     pub fn default_download_dir(&self) -> PathBuf {
         self.inner.lock().downloads.clone()
     }
 
-    /// Confirm or cancel Save As for an in-progress remote `sz` download.
-    /// `None` cancels the transfer. Returns wire bytes the caller must send.
+    /// Confirm Save As for remote `sz`. `None` cancels.
+    ///
+    /// Until this returns Ok with a path, the receiver does **not** ACK the
+    /// file (ZRPOS stays queued) so the remote cannot finish early.
     pub fn provide_download_path(&self, path: Option<PathBuf>) -> Result<Vec<u8>, String> {
         let mut g = self.inner.lock();
         let Stage::Recv(recv) = &mut g.stage else {
@@ -172,11 +182,8 @@ impl ZmodemBridge {
         if !recv.awaiting_save {
             return Err("no pending ZMODEM Save As".into());
         }
+
         if path.is_none() {
-            if let Some(temp) = recv.temp_path.take() {
-                drop(recv.file.take());
-                let _ = fs::remove_file(temp);
-            }
             g.stage = Stage::Idle {
                 pending: Vec::new(),
             };
@@ -185,46 +192,28 @@ impl ZmodemBridge {
             };
             return Ok(Self::cancel_bytes().to_vec());
         }
+
         let dest = path.unwrap();
         if let Some(parent) = dest.parent() {
             fs::create_dir_all(parent).map_err(|e| format!("mkdir {parent:?}: {e}"))?;
         }
-        if let Some(f) = recv.file.as_mut() {
-            let _ = f.sync_all();
-        }
-        drop(recv.file.take());
-        if let Some(temp) = recv.temp_path.take() {
-            if temp != dest {
-                if fs::rename(&temp, &dest).is_err() {
-                    fs::copy(&temp, &dest).map_err(|e| format!("save {dest:?}: {e}"))?;
-                    let _ = fs::remove_file(&temp);
-                }
-            }
-        } else {
-            // Header seen but no bytes yet — create an empty file at the destination.
-            File::create(&dest).map_err(|e| format!("create {dest:?}: {e}"))?;
-        }
-        if !recv.file_finished {
-            recv.file = Some(
-                OpenOptions::new()
-                    .append(true)
-                    .open(&dest)
-                    .map_err(|e| format!("reopen {dest:?}: {e}"))?,
-            );
-        }
+        let f = File::create(&dest).map_err(|e| format!("create {dest:?}: {e}"))?;
+        recv.file = Some(f);
         recv.path = Some(dest.clone());
         recv.awaiting_save = false;
         g.status = ZmodemStatus::Receiving {
             file_name: recv.name.clone(),
-            bytes: recv.written,
+            bytes: 0,
             total: recv.total,
         };
-        tracing::info!("ZMODEM saving → {}", dest.display());
-        Ok(Vec::new())
+        tracing::info!("ZMODEM receiving → {}", dest.display());
+
+        let mut out = Vec::new();
+        run_recv(&mut g, &[], &mut out)?;
+        Ok(out)
     }
 
-    /// Provide local files for an in-progress remote `rz` (upload) session.
-    /// Returns wire bytes the caller must send. Empty `paths` cancels.
+    /// Start upload for remote `rz`. Empty `paths` cancels.
     pub fn provide_upload_files(&self, paths: Vec<PathBuf>) -> Result<Vec<u8>, String> {
         let mut g = self.inner.lock();
         let Stage::AwaitSend { zrinit } = &g.stage else {
@@ -263,8 +252,6 @@ impl ZmodemBridge {
         Ok(out)
     }
 
-    /// Feed bytes from the remote. Caller writes `to_wire` and forwards
-    /// `to_terminal` to the emulator.
     pub fn on_rx(&self, data: &[u8]) -> RxResult {
         let mut g = self.inner.lock();
         let mut to_wire = Vec::new();
@@ -273,8 +260,6 @@ impl ZmodemBridge {
                 pending.extend_from_slice(data);
                 match classify_pending(pending) {
                     Detect::NeedMore => {
-                        // Hold only a short ambiguous suffix so normal output
-                        // ending in '*' is not stuck forever.
                         let hold = ambiguous_suffix_len(pending);
                         if pending.len() > hold {
                             let flush_len = pending.len() - hold;
@@ -307,6 +292,7 @@ impl ZmodemBridge {
                         let text = pending[..prefix_len].to_vec();
                         let frame = pending[prefix_len..].to_vec();
                         pending.clear();
+                        // Stall: do not create a Sender until the UI picks files.
                         g.stage = Stage::AwaitSend { zrinit: frame };
                         g.status = ZmodemStatus::AwaitingUpload;
                         text
@@ -323,10 +309,12 @@ impl ZmodemBridge {
                     g.stage = Stage::Idle {
                         pending: Vec::new(),
                     };
+                    to_wire.extend_from_slice(Self::cancel_bytes());
                 }
                 Vec::new()
             }
             Stage::AwaitSend { zrinit } => {
+                // Keep buffering remote bytes; still no Sender until UI confirms.
                 zrinit.extend_from_slice(data);
                 Vec::new()
             }
@@ -361,7 +349,6 @@ fn classify_pending(buf: &[u8]) -> Detect {
         return match (t0, t1) {
             (b'0', b'0') => Detect::RemoteSend(i),
             (b'0', b'1') => Detect::RemoteRecv(i),
-            // Other hex header types: treat as send-side initiation.
             _ => Detect::RemoteSend(i),
         };
     }
@@ -377,7 +364,6 @@ fn classify_pending(buf: &[u8]) -> Detect {
     Detect::None
 }
 
-/// Bytes at the end that might be the start of `**\x18B..` or `*\x18A/B/C`.
 fn ambiguous_suffix_len(buf: &[u8]) -> usize {
     if buf.is_empty() {
         return 0;
@@ -428,13 +414,11 @@ fn start_recv(
             engine,
             file: None,
             path: None,
-            temp_path: None,
             name: String::new(),
             written: 0,
             total: None,
             inbox: frame,
             awaiting_save: false,
-            file_finished: false,
         }),
         status: ZmodemStatus::Receiving {
             file_name: String::new(),
@@ -448,7 +432,6 @@ fn start_recv(
 }
 
 fn run_recv(inner: &mut Inner, data: &[u8], to_wire: &mut Vec<u8>) -> Result<(), String> {
-    let downloads = inner.downloads.clone();
     let Stage::Recv(recv) = &mut inner.stage else {
         return Ok(());
     };
@@ -456,7 +439,21 @@ fn run_recv(inner: &mut Inner, data: &[u8], to_wire: &mut Vec<u8>) -> Result<(),
         recv.inbox.extend_from_slice(data);
     }
 
+    // Paused for Save As: keep wire bytes in inbox / engine, but do not ACK
+    // (WriteWire) or accept file data until a path is chosen.
+    if recv.awaiting_save && recv.file.is_none() {
+        return Ok(());
+    }
+
     loop {
+        // Re-check pause (e.g. multi-file next Save As).
+        let Stage::Recv(recv) = &mut inner.stage else {
+            return Ok(());
+        };
+        if recv.awaiting_save && recv.file.is_none() {
+            return Ok(());
+        }
+
         if !recv.inbox.is_empty() {
             let n = recv
                 .engine
@@ -476,59 +473,41 @@ fn run_recv(inner: &mut Inner, data: &[u8], to_wire: &mut Vec<u8>) -> Result<(),
                 let f = recv
                     .file
                     .as_mut()
-                    .ok_or_else(|| "zmodem data before file start".to_string())?;
+                    .ok_or_else(|| "zmodem data before Save As".to_string())?;
                 f.write_all(&owned)
                     .map_err(|e| format!("write download: {e}"))?;
                 recv.written += owned.len() as u64;
                 recv.engine
                     .file_written(owned.len())
                     .map_err(|e| format!("zmodem file_written: {e:?}"))?;
-                if !recv.awaiting_save {
-                    inner.status = ZmodemStatus::Receiving {
-                        file_name: recv.name.clone(),
-                        bytes: recv.written,
-                        total: recv.total,
-                    };
-                }
+                inner.status = ZmodemStatus::Receiving {
+                    file_name: recv.name.clone(),
+                    bytes: recv.written,
+                    total: recv.total,
+                };
             }
             Action::Event(Event::FileStarted(info)) => {
                 let safe = sanitize_name(info.name);
                 let total = info.size.map(|p| u64::from(p.get()));
-                // A previous file still waiting on Save As — keep it under Downloads.
-                if recv.awaiting_save {
-                    finalize_unsaved_recv(recv, &downloads)?;
-                }
-                let temp = unique_path(
-                    &downloads,
-                    &format!(".vsterm-zmodem-{safe}.part"),
-                );
-                let f = File::create(&temp).map_err(|e| format!("create {temp:?}: {e}"))?;
-                recv.file = Some(f);
-                recv.temp_path = Some(temp);
-                recv.path = None;
                 recv.name = safe.clone();
                 recv.written = 0;
                 recv.total = total;
+                recv.path = None;
+                drop(recv.file.take());
                 recv.awaiting_save = true;
-                recv.file_finished = false;
                 inner.status = ZmodemStatus::AwaitingSaveAs {
                     suggested_name: safe,
                     total,
                 };
+                // Leave ZRPOS queued inside the engine until Save As confirms.
+                return Ok(());
             }
             Action::Event(Event::FileCompleted) => {
-                if let Some(f) = recv.file.as_mut() {
+                if let Some(f) = recv.file.take() {
                     let _ = f.sync_all();
                 }
-                if !recv.awaiting_save {
-                    drop(recv.file.take());
-                }
-                recv.file_finished = true;
             }
             Action::Event(Event::SessionCompleted) => {
-                if recv.awaiting_save {
-                    finalize_unsaved_recv(recv, &downloads)?;
-                }
                 let summary = recv
                     .path
                     .as_ref()
@@ -569,7 +548,10 @@ fn run_send(inner: &mut Inner, data: &[u8], to_wire: &mut Vec<u8>) -> Result<(),
         try_offer_file(send, &mut inner.status)?;
     }
 
-    loop {
+    // Bound work per call so the UI/reader never holds the mutex while
+    // streaming an entire multi‑MB file in one go.
+    const MAX_ACTIONS: usize = 64;
+    for _ in 0..MAX_ACTIONS {
         let Stage::Send(send) = &mut inner.stage else {
             return Ok(());
         };
@@ -641,26 +623,6 @@ fn run_send(inner: &mut Inner, data: &[u8], to_wire: &mut Vec<u8>) -> Result<(),
     Ok(())
 }
 
-fn finalize_unsaved_recv(recv: &mut RecvState, downloads: &Path) -> Result<(), String> {
-    if let Some(f) = recv.file.as_mut() {
-        let _ = f.sync_all();
-    }
-    drop(recv.file.take());
-    let dest = unique_path(downloads, &recv.name);
-    if let Some(temp) = recv.temp_path.take() {
-        if fs::rename(&temp, &dest).is_err() {
-            fs::copy(&temp, &dest).map_err(|e| format!("save {dest:?}: {e}"))?;
-            let _ = fs::remove_file(&temp);
-        }
-    } else {
-        File::create(&dest).map_err(|e| format!("create {dest:?}: {e}"))?;
-    }
-    recv.path = Some(dest);
-    recv.awaiting_save = false;
-    recv.file_finished = true;
-    Ok(())
-}
-
 fn try_offer_file(send: &mut SendState, status: &mut ZmodemStatus) -> Result<(), String> {
     if send.offered || send.index >= send.files.len() {
         return Ok(());
@@ -715,30 +677,6 @@ fn sanitize_name(raw: &[u8]) -> String {
     }
 }
 
-fn unique_path(dir: &Path, name: &str) -> PathBuf {
-    let _ = fs::create_dir_all(dir);
-    let candidate = dir.join(name);
-    if !candidate.exists() {
-        return candidate;
-    }
-    let stem = Path::new(name)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("file");
-    let ext = Path::new(name)
-        .extension()
-        .and_then(|s| s.to_str())
-        .map(|e| format!(".{e}"))
-        .unwrap_or_default();
-    for i in 1..10_000 {
-        let p = dir.join(format!("{stem}-{i}{ext}"));
-        if !p.exists() {
-            return p;
-        }
-    }
-    dir.join(format!("{stem}-dup{ext}"))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -772,5 +710,15 @@ mod tests {
     fn sanitize_strips_path() {
         assert_eq!(sanitize_name(b"../../etc/passwd"), "passwd");
         assert_eq!(sanitize_name(b"ok_file.txt"), "ok_file.txt");
+    }
+
+    #[test]
+    fn progress_fraction_known_total() {
+        let s = ZmodemStatus::Receiving {
+            file_name: "a".into(),
+            bytes: 50,
+            total: Some(100),
+        };
+        assert!((s.progress_fraction().unwrap() - 0.5).abs() < f32::EPSILON);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题
1. **内存**：连上服务器 RSS 涨 10–20MB，断开/关 tab 后回收不全。
2. **ZMODEM**：`sz` 另存为未确认就已下完，点确定后卡住；`rz` 类似；缺少进度条。

## 修复
### ZMODEM
- 拿到远端文件名（`sz`）或 ZRINIT（`rz`）后**暂停协议**：不 ACK / 不发文件数据，直到对话框确认。
- 去掉「先写临时文件、对话框还开着就传完」的路径，避免确认时状态已 Idle 导致卡死。
- 发送侧限制单次 `poll` 动作数量，避免 UI 线程长时间持锁。
- 状态栏增加**进度条**（有总大小时显示百分比；等待对话框时显示动画条）+ 取消按钮。

### 内存
- 关闭 tab 时在**后台线程** drop 连接（与 `close_all` 一致），避免 UI 线程拖住 russh/reader。
- `RusshRemoteExec::Drop` 主动 `disconnect` SSH 会话并关闭 SFTP。
- 关 tab 前先解绑 `RemoteHostService`，并 `forget_host` 清掉该主机的监控缓存；缓存软上限 16。

## 测试建议
- `sz file`：另存为弹出后远端应等待；确认后才开始传，状态栏有进度；取消对话框应中止。
- `rz`：选文件确认后才上传；有进度。
- 连接 → 关 tab，观察 RSS 是否明显回落（仍可能有分配器不归还 OS 的残留，但不应每连一次就永久 +10–20MB）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9e2800f-61d1-4baa-a3f3-c15665d58d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9e2800f-61d1-4baa-a3f3-c15665d58d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

