### PR TITLE
ZMODEM：清 rz 残留并统一文件区进度条

### DIFF
--- a/crates/app-ui/src/app.rs
+++ b/crates/app-ui/src/app.rs
@@ -1566,9 +1566,8 @@ impl eframe::App for VsTermApp {
         });
 
         egui::TopBottomPanel::bottom("status_bar").show(ctx, |ui| {
-            let zmodem = self.connections.active_zmodem_status();
             let zmodem_busy = matches!(
-                zmodem,
+                self.connections.active_zmodem_status(),
                 Some(
                     ZmodemStatus::Receiving { .. }
                         | ZmodemStatus::Sending { .. }
@@ -1576,14 +1575,12 @@ impl eframe::App for VsTermApp {
                         | ZmodemStatus::AwaitingSaveAs { .. }
                 )
             );
-            let zmodem_progress = zmodem.as_ref().and_then(|s| s.progress_fraction());
             status_bar::show(
                 ui,
                 &self.status,
                 self.connections.list_meta().len(),
                 crate::render_policy::is_software_renderer(),
                 zmodem_busy,
-                zmodem_progress,
                 || {
                     let _ = self.connections.cancel_zmodem();
                 },
@@ -1861,6 +1858,9 @@ impl eframe::App for VsTermApp {
                                     format!("{}: {err}", i18n::t("status.open_failed"));
                             }
                         }
+                        if bottom_panel::take_zmodem_cancel(&mut self.bottom) {
+                            let _ = self.connections.cancel_zmodem();
+                        }
                     });
 
                     ui.advance_cursor_after_rect(full);
@@ -2038,6 +2038,13 @@ impl VsTermApp {
             }) => {
                 self.status =
                     format_zmodem_progress(i18n::t("zmodem.receiving"), &file_name, bytes, total);
+                bottom_panel::sync_zmodem_progress(
+                    &mut self.bottom,
+                    &file_name,
+                    bytes,
+                    total,
+                    false,
+                );
                 self.pending_zmodem_pick = None;
             }
             Some(ZmodemStatus::Sending {
@@ -2047,10 +2054,24 @@ impl VsTermApp {
             }) => {
                 self.status =
                     format_zmodem_progress(i18n::t("zmodem.sending"), &file_name, bytes, total);
+                bottom_panel::sync_zmodem_progress(
+                    &mut self.bottom,
+                    &file_name,
+                    bytes,
+                    total,
+                    true,
+                );
                 self.pending_zmodem_pick = None;
             }
             Some(ZmodemStatus::AwaitingUpload { prompt_id }) => {
                 self.status = i18n::t("zmodem.await_upload");
+                bottom_panel::sync_zmodem_progress(
+                    &mut self.bottom,
+                    &i18n::t("zmodem.await_upload"),
+                    0,
+                    None,
+                    true,
+                );
                 let already = matches!(
                     &self.pending_zmodem_pick,
                     Some(PendingZmodemPick {
@@ -2079,6 +2100,13 @@ impl VsTermApp {
                     ),
                     _ => format!("{}: {suggested_name}", i18n::t("zmodem.await_save")),
                 };
+                bottom_panel::sync_zmodem_progress(
+                    &mut self.bottom,
+                    &suggested_name,
+                    0,
+                    total,
+                    false,
+                );
                 let already = matches!(
                     &self.pending_zmodem_pick,
                     Some(PendingZmodemPick {
@@ -2097,21 +2125,56 @@ impl VsTermApp {
                 }
             }
             Some(ZmodemStatus::Done { summary }) => {
-                self.status = summary;
+                self.status = summary.clone();
+                let (name, is_upload) = zmodem_transfer_identity(&self.bottom, &summary, true);
+                bottom_panel::finish_zmodem_transfer(
+                    &mut self.bottom,
+                    &name,
+                    is_upload,
+                    true,
+                    summary,
+                );
                 self.connections.clear_zmodem_finished();
                 self.pending_zmodem_pick = None;
             }
             Some(ZmodemStatus::Failed { message }) => {
-                self.status = message;
+                self.status = message.clone();
+                let (name, is_upload) = zmodem_transfer_identity(&self.bottom, &message, false);
+                bottom_panel::finish_zmodem_transfer(
+                    &mut self.bottom,
+                    &name,
+                    is_upload,
+                    false,
+                    message,
+                );
                 self.connections.clear_zmodem_finished();
                 self.pending_zmodem_pick = None;
             }
             Some(ZmodemStatus::Idle) | None => {
                 // Drop any deferred picker — transfer is over, keyboard is free.
                 self.pending_zmodem_pick = None;
+                bottom_panel::clear_zmodem_transfer(&mut self.bottom);
             }
         }
     }
+}
+
+/// Prefer the live progress-bar label; fall back to a short summary leaf.
+fn zmodem_transfer_identity(
+    bottom: &BottomPanelState,
+    summary: &str,
+    ok: bool,
+) -> (String, bool) {
+    if let Some((name, is_upload)) = bottom_panel::zmodem_transfer_label(bottom) {
+        return (name, is_upload);
+    }
+    let _ = ok;
+    let name = summary
+        .rsplit([' ', '/', '\\'])
+        .find(|s| !s.is_empty())
+        .unwrap_or("ZMODEM")
+        .to_string();
+    (name, true)
 }
 
 fn format_zmodem_progress(kind: String, name: &str, bytes: u64, total: Option<u64>) -> String {

--- a/crates/app-ui/src/panels/bottom_panel.rs
+++ b/crates/app-ui/src/panels/bottom_panel.rs
@@ -40,6 +40,8 @@ struct ActiveTransfer {
     refresh_remote_on_ok: bool,
     open_after: Option<OpenAfter>,
     is_upload: bool,
+    /// Driven by ZMODEM (rz/sz) rather than an SFTP worker thread.
+    is_zmodem: bool,
     started: Instant,
     last_bytes: u64,
     last_sample: Instant,
@@ -172,6 +174,8 @@ pub struct BottomPanelState {
     /// Set by a menu/button click; drained at the start of the next `tick_files`
     /// so the context menu can close and repaint before the blocking OS dialog.
     pending_native_dialog: Option<PendingNativeDialog>,
+    /// Files-panel Cancel clicked while a ZMODEM transfer owns the progress bar.
+    zmodem_cancel_requested: bool,
     /// Per-server file-browser views, keyed by `user@host`. Switching server
     /// tabs stashes the outgoing view here and restores the target's, so the
     /// panel keeps each host's directory/listing instead of resetting to `/`
@@ -294,6 +298,7 @@ impl Default for BottomPanelState {
             status_line: None,
             inline_rename: None,
             pending_native_dialog: None,
+            zmodem_cancel_requested: false,
             saved: HashMap::new(),
         }
     }
@@ -379,7 +384,11 @@ pub fn show(
 
             if do_cancel {
                 if let Some(t) = &state.transfer {
-                    t.progress.request_cancel();
+                    if t.is_zmodem {
+                        state.zmodem_cancel_requested = true;
+                    } else {
+                        t.progress.request_cancel();
+                    }
                 }
             }
         }
@@ -1676,6 +1685,106 @@ pub fn needs_transfer_poll(state: &BottomPanelState) -> bool {
         || state.remote_loading
 }
 
+/// Drain a Cancel click that targeted a ZMODEM-owned progress bar.
+pub fn take_zmodem_cancel(state: &mut BottomPanelState) -> bool {
+    std::mem::take(&mut state.zmodem_cancel_requested)
+}
+
+/// Mirror ZMODEM send/receive progress into the files-panel transfer strip
+/// (same square bar + transfer list as SFTP). No-ops if an SFTP transfer owns
+/// the slot.
+pub fn sync_zmodem_progress(
+    state: &mut BottomPanelState,
+    name: &str,
+    bytes: u64,
+    total: Option<u64>,
+    is_upload: bool,
+) {
+    let label = if name.is_empty() {
+        "ZMODEM".to_string()
+    } else {
+        name.to_string()
+    };
+    match state.transfer.as_mut() {
+        Some(xfer) if xfer.is_zmodem => {
+            xfer.label = label;
+            xfer.is_upload = is_upload;
+            xfer.progress.set(bytes, total);
+        }
+        Some(_) => {
+            // SFTP is using the bar — leave it alone.
+        }
+        None => {
+            let progress = ArcProgress::new();
+            progress.set(bytes, total);
+            let now = Instant::now();
+            state.transfer = Some(ActiveTransfer {
+                label,
+                progress,
+                refresh_remote_on_ok: false,
+                open_after: None,
+                is_upload,
+                is_zmodem: true,
+                started: now,
+                last_bytes: 0,
+                last_sample: now,
+                speed_bps: 0.0,
+            });
+            state.status_line = None;
+        }
+    }
+}
+
+/// Finish a ZMODEM transfer: clear the square progress bar and append a row to
+/// the shared transfer list (same place as SFTP).
+pub fn finish_zmodem_transfer(
+    state: &mut BottomPanelState,
+    name: &str,
+    is_upload: bool,
+    ok: bool,
+    detail: String,
+) {
+    let leaf = if name.is_empty() {
+        "ZMODEM".to_string()
+    } else {
+        path_leaf(name).to_string()
+    };
+    if state.transfer.as_ref().is_some_and(|t| t.is_zmodem) {
+        state.transfer = None;
+    }
+    push_transfer_log(
+        state,
+        TransferLogItem {
+            name: leaf.clone(),
+            is_upload,
+            ok,
+            detail: detail.clone(),
+        },
+    );
+    state.status_line = Some(if ok {
+        format!("{} — {leaf}", i18n::t("bottom.files.transfer_ok"))
+    } else {
+        format!("{}: {detail}", i18n::t("bottom.files.transfer_failed"))
+    });
+}
+
+/// Label / direction of the live ZMODEM progress slot, if any.
+pub fn zmodem_transfer_label(state: &BottomPanelState) -> Option<(String, bool)> {
+    state
+        .transfer
+        .as_ref()
+        .filter(|t| t.is_zmodem)
+        .map(|t| (t.label.clone(), t.is_upload))
+}
+
+/// Drop an unfinished ZMODEM progress slot (e.g. session went Idle without a
+/// Done/Failed event). Does not touch SFTP transfers.
+pub fn clear_zmodem_transfer(state: &mut BottomPanelState) {
+    if state.transfer.as_ref().is_some_and(|t| t.is_zmodem) {
+        state.transfer = None;
+    }
+}
+
 pub fn run_native_dialog(
     state: &mut BottomPanelState,
     remote: Option<&RemoteSession>,
@@ -2064,6 +2173,7 @@ fn start_download(
         refresh_remote_on_ok: false,
         open_after,
         is_upload: false,
+        is_zmodem: false,
         started: now,
         last_bytes: 0,
         last_sample: now,
@@ -2108,6 +2218,7 @@ fn start_upload(state: &mut BottomPanelState, remote: Option<&RemoteSession>, lo
         refresh_remote_on_ok: true,
         open_after: None,
         is_upload: true,
+        is_zmodem: false,
         started: now,
         last_bytes: 0,
         last_sample: now,

--- a/crates/app-ui/src/panels/status_bar.rs
+++ b/crates/app-ui/src/panels/status_bar.rs
@@ -7,24 +7,10 @@ pub fn show(
     conn_count: usize,
     software_renderer: bool,
     zmodem_busy: bool,
-    zmodem_progress: Option<f32>,
     on_cancel_zmodem: impl FnOnce(),
 ) {
     ui.horizontal(|ui| {
         ui.label(status);
-        if let Some(frac) = zmodem_progress {
-            let bar = egui::ProgressBar::new(frac)
-                .desired_width(120.0)
-                .show_percentage();
-            ui.add(bar);
-        } else if zmodem_busy {
-            // Indeterminate-ish: thin busy bar while waiting on a dialog.
-            ui.add(
-                egui::ProgressBar::new(0.0)
-                    .desired_width(120.0)
-                    .animate(true),
-            );
-        }
         if zmodem_busy {
             if ui
                 .small_button(i18n::t("zmodem.cancel"))

--- a/crates/term-core/src/zmodem.rs
+++ b/crates/term-core/src/zmodem.rs
@@ -20,9 +20,9 @@ use zmodem2::{Action, Event, FileInfo, Position, Receiver, Sender};
 /// Ignore new ZMODEM handshakes for this long after a session ends.
 const POST_SESSION_COOLDOWN: Duration = Duration::from_millis(2_000);
 
-/// CR + CSI erase-in-line (entire). Wipes banners like `rz waiting to receive.`
-/// so the shell prompt does not leave a residue such as `ve.` after `\r` overwrite.
-const CLEAR_LINE: &[u8] = b"\r\x1b[2K";
+/// Move to the next line so the shell prompt cannot `\r`-overwrite a leftover
+/// banner such as `rz waiting to receive.` (which otherwise leaves a `ve.` stump).
+const ADVANCE_LINE: &[u8] = b"\n";
 
 /// Result of feeding remote bytes through the ZMODEM gate.
 #[derive(Debug, Default)]
@@ -182,7 +182,7 @@ impl ZmodemBridge {
             ZmodemStatus::Failed {
                 message: "ZMODEM transfer cancelled".into(),
             },
-            CLEAR_LINE.to_vec(),
+            ADVANCE_LINE.to_vec(),
         );
         Self::cancel_bytes().to_vec()
     }
@@ -207,7 +207,7 @@ impl ZmodemBridge {
                 ZmodemStatus::Failed {
                     message: "ZMODEM download cancelled".into(),
                 },
-                CLEAR_LINE.to_vec(),
+                ADVANCE_LINE.to_vec(),
             );
             return Ok(Self::cancel_bytes().to_vec());
         }
@@ -244,7 +244,7 @@ impl ZmodemBridge {
                 ZmodemStatus::Failed {
                     message: "ZMODEM upload cancelled".into(),
                 },
-                CLEAR_LINE.to_vec(),
+                ADVANCE_LINE.to_vec(),
             );
             return Ok(Self::cancel_bytes().to_vec());
         }
@@ -344,10 +344,10 @@ impl ZmodemBridge {
                     let prompt_id = next_prompt_id(&mut g);
                     g.stage = Stage::AwaitSend { zrinit: frame };
                     g.status = ZmodemStatus::AwaitingUpload { prompt_id };
-                    // Keep any non-banner prefix, then wipe the current line so
-                    // `rz waiting to receive.` cannot linger under the prompt.
+                    // Keep any non-banner prefix, then advance so a later
+                    // prompt lands on a fresh line instead of `\r`-overwriting.
                     to_terminal = text;
-                    to_terminal.extend_from_slice(CLEAR_LINE);
+                    to_terminal.extend_from_slice(ADVANCE_LINE);
                 }
             }
         } else if matches!(g.stage, Stage::Recv(_) | Stage::Send(_)) {
@@ -359,14 +359,14 @@ impl ZmodemBridge {
                 enter_finished(
                     &mut g,
                     ZmodemStatus::Failed { message: msg },
-                    CLEAR_LINE.to_vec(),
+                    ADVANCE_LINE.to_vec(),
                 );
                 to_wire.extend_from_slice(Self::cancel_bytes());
             }
         }
 
-        // Prepend so a post-session clear runs before the next shell prompt
-        // (cancel stores CLEAR_LINE in flush; prompt arrives on a later on_rx).
+        // Prepend so a post-session newline runs before the next shell prompt
+        // (cancel stores ADVANCE_LINE in flush; prompt arrives on a later on_rx).
         if !g.flush_to_terminal.is_empty() {
             let mut flush = std::mem::take(&mut g.flush_to_terminal);
             flush.append(&mut to_terminal);
@@ -402,8 +402,8 @@ fn enter_finished(inner: &mut Inner, status: ZmodemStatus, leftover_to_terminal:
     }
 }
 
-fn with_clear_line(mut leftover: Vec<u8>) -> Vec<u8> {
-    let mut out = CLEAR_LINE.to_vec();
+fn with_advance_line(mut leftover: Vec<u8>) -> Vec<u8> {
+    let mut out = ADVANCE_LINE.to_vec();
     out.append(&mut leftover);
     out
 }
@@ -623,13 +623,13 @@ fn run_recv(inner: &mut Inner, data: &[u8], to_wire: &mut Vec<u8>) -> Result<(),
                     .as_ref()
                     .map(|p| format!("ZMODEM saved {}", p.display()))
                     .unwrap_or_else(|| "ZMODEM receive complete".into());
-                let leftover = with_clear_line(std::mem::take(&mut recv.inbox));
+                let leftover = with_advance_line(std::mem::take(&mut recv.inbox));
                 enter_finished(inner, ZmodemStatus::Done { summary }, leftover);
                 return Ok(());
             }
             Action::Event(Event::Aborted) => {
                 drain_write_wire_receiver(&mut recv.engine, to_wire);
-                let leftover = with_clear_line(std::mem::take(&mut recv.inbox));
+                let leftover = with_advance_line(std::mem::take(&mut recv.inbox));
                 enter_finished(
                     inner,
                     ZmodemStatus::Failed {
@@ -727,8 +727,8 @@ fn run_send(inner: &mut Inner, data: &[u8], to_wire: &mut Vec<u8>) -> Result<(),
             Action::Event(Event::SessionCompleted) => {
                 // Drain OO (and any final ZFIN response bytes) before Idle.
                 drain_write_wire_sender(&mut send.engine, to_wire);
-                // Clear `rz waiting to receive.` before leftover/shell prompt.
-                let leftover = with_clear_line(std::mem::take(&mut send.inbox));
+                // Advance past `rz waiting to receive.` before leftover/prompt.
+                let leftover = with_advance_line(std::mem::take(&mut send.inbox));
                 enter_finished(
                     inner,
                     ZmodemStatus::Done {
@@ -741,7 +741,7 @@ fn run_send(inner: &mut Inner, data: &[u8], to_wire: &mut Vec<u8>) -> Result<(),
             Action::Event(Event::FileStarted(_)) => {}
             Action::Event(Event::Aborted) => {
                 drain_write_wire_sender(&mut send.engine, to_wire);
-                let leftover = with_clear_line(std::mem::take(&mut send.inbox));
+                let leftover = with_advance_line(std::mem::take(&mut send.inbox));
                 enter_finished(
                     inner,
                     ZmodemStatus::Failed {
@@ -867,9 +867,9 @@ mod tests {
     }
 
     #[test]
-    fn with_clear_line_prefixes_csi() {
-        let out = with_clear_line(b"prompt".to_vec());
-        assert!(out.starts_with(CLEAR_LINE));
+    fn with_advance_line_prefixes_newline() {
+        let out = with_advance_line(b"prompt".to_vec());
+        assert!(out.starts_with(ADVANCE_LINE));
         assert!(out.ends_with(b"prompt"));
     }
 }

--- a/crates/term-core/src/zmodem.rs
+++ b/crates/term-core/src/zmodem.rs
@@ -20,6 +20,10 @@ use zmodem2::{Action, Event, FileInfo, Position, Receiver, Sender};
 /// Ignore new ZMODEM handshakes for this long after a session ends.
 const POST_SESSION_COOLDOWN: Duration = Duration::from_millis(2_000);
 
+/// CR + CSI erase-in-line (entire). Wipes banners like `rz waiting to receive.`
+/// so the shell prompt does not leave a residue such as `ve.` after `\r` overwrite.
+const CLEAR_LINE: &[u8] = b"\r\x1b[2K";
+
 /// Result of feeding remote bytes through the ZMODEM gate.
 #[derive(Debug, Default)]
 pub struct RxResult {
@@ -178,7 +182,7 @@ impl ZmodemBridge {
             ZmodemStatus::Failed {
                 message: "ZMODEM transfer cancelled".into(),
             },
-            Vec::new(),
+            CLEAR_LINE.to_vec(),
         );
         Self::cancel_bytes().to_vec()
     }
@@ -203,7 +207,7 @@ impl ZmodemBridge {
                 ZmodemStatus::Failed {
                     message: "ZMODEM download cancelled".into(),
                 },
-                Vec::new(),
+                CLEAR_LINE.to_vec(),
             );
             return Ok(Self::cancel_bytes().to_vec());
         }
@@ -240,7 +244,7 @@ impl ZmodemBridge {
                 ZmodemStatus::Failed {
                     message: "ZMODEM upload cancelled".into(),
                 },
-                Vec::new(),
+                CLEAR_LINE.to_vec(),
             );
             return Ok(Self::cancel_bytes().to_vec());
         }
@@ -340,7 +344,10 @@ impl ZmodemBridge {
                     let prompt_id = next_prompt_id(&mut g);
                     g.stage = Stage::AwaitSend { zrinit: frame };
                     g.status = ZmodemStatus::AwaitingUpload { prompt_id };
+                    // Keep any non-banner prefix, then wipe the current line so
+                    // `rz waiting to receive.` cannot linger under the prompt.
                     to_terminal = text;
+                    to_terminal.extend_from_slice(CLEAR_LINE);
                 }
             }
         } else if matches!(g.stage, Stage::Recv(_) | Stage::Send(_)) {
@@ -352,14 +359,18 @@ impl ZmodemBridge {
                 enter_finished(
                     &mut g,
                     ZmodemStatus::Failed { message: msg },
-                    Vec::new(),
+                    CLEAR_LINE.to_vec(),
                 );
                 to_wire.extend_from_slice(Self::cancel_bytes());
             }
         }
 
+        // Prepend so a post-session clear runs before the next shell prompt
+        // (cancel stores CLEAR_LINE in flush; prompt arrives on a later on_rx).
         if !g.flush_to_terminal.is_empty() {
-            to_terminal.append(&mut g.flush_to_terminal);
+            let mut flush = std::mem::take(&mut g.flush_to_terminal);
+            flush.append(&mut to_terminal);
+            to_terminal = flush;
         }
         RxResult {
             to_terminal,
@@ -389,6 +400,12 @@ fn enter_finished(inner: &mut Inner, status: ZmodemStatus, leftover_to_terminal:
     if !leftover_to_terminal.is_empty() {
         inner.flush_to_terminal.extend_from_slice(&leftover_to_terminal);
     }
+}
+
+fn with_clear_line(mut leftover: Vec<u8>) -> Vec<u8> {
+    let mut out = CLEAR_LINE.to_vec();
+    out.append(&mut leftover);
+    out
 }
 
 /// After SessionCompleted/Aborted events, zmodem2 still has ZFIN/OO queued.
@@ -606,13 +623,13 @@ fn run_recv(inner: &mut Inner, data: &[u8], to_wire: &mut Vec<u8>) -> Result<(),
                     .as_ref()
                     .map(|p| format!("ZMODEM saved {}", p.display()))
                     .unwrap_or_else(|| "ZMODEM receive complete".into());
-                let leftover = std::mem::take(&mut recv.inbox);
+                let leftover = with_clear_line(std::mem::take(&mut recv.inbox));
                 enter_finished(inner, ZmodemStatus::Done { summary }, leftover);
                 return Ok(());
             }
             Action::Event(Event::Aborted) => {
                 drain_write_wire_receiver(&mut recv.engine, to_wire);
-                let leftover = std::mem::take(&mut recv.inbox);
+                let leftover = with_clear_line(std::mem::take(&mut recv.inbox));
                 enter_finished(
                     inner,
                     ZmodemStatus::Failed {
@@ -710,7 +727,8 @@ fn run_send(inner: &mut Inner, data: &[u8], to_wire: &mut Vec<u8>) -> Result<(),
             Action::Event(Event::SessionCompleted) => {
                 // Drain OO (and any final ZFIN response bytes) before Idle.
                 drain_write_wire_sender(&mut send.engine, to_wire);
-                let leftover = std::mem::take(&mut send.inbox);
+                // Clear `rz waiting to receive.` before leftover/shell prompt.
+                let leftover = with_clear_line(std::mem::take(&mut send.inbox));
                 enter_finished(
                     inner,
                     ZmodemStatus::Done {
@@ -723,7 +741,7 @@ fn run_send(inner: &mut Inner, data: &[u8], to_wire: &mut Vec<u8>) -> Result<(),
             Action::Event(Event::FileStarted(_)) => {}
             Action::Event(Event::Aborted) => {
                 drain_write_wire_sender(&mut send.engine, to_wire);
-                let leftover = std::mem::take(&mut send.inbox);
+                let leftover = with_clear_line(std::mem::take(&mut send.inbox));
                 enter_finished(
                     inner,
                     ZmodemStatus::Failed {
@@ -846,5 +864,12 @@ mod tests {
             total: Some(100),
         };
         assert!((s.progress_fraction().unwrap() - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn with_clear_line_prefixes_csi() {
+        let out = with_clear_line(b"prompt".to_vec());
+        assert!(out.starts_with(CLEAR_LINE));
+        assert!(out.ends_with(b"prompt"));
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题
1. `rz` 结束后 shell 用 `\r` 覆盖 `waiting to receive.`，光标旁残留 `ve.`
2. 状态栏 egui `ProgressBar` 为圆角，与文件区方角进度条不一致

## 改动
- **rz 残留**：会话开始/结束/取消时注入换行 `\n`，让提示符落在下一行，避免 `\r` 盖不全（比 CSI 清行更简单；上一行会保留 `rz waiting to receive.`）
- **进度条**：rz/sz 进度接入文件操作区底部方角条 + 传输列表（与 SFTP 同源）；应用底栏去掉圆角 ProgressBar，保留「取消传输」按钮

## 验证
- `cargo test -p term-core --lib zmodem`
- `cargo check -p app-ui`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9e2800f-61d1-4baa-a3f3-c15665d58d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9e2800f-61d1-4baa-a3f3-c15665d58d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

