### PR TITLE
Focus terminal after connect and fix first-login bottom black band

### DIFF
--- a/crates/app-ui/src/app.rs
+++ b/crates/app-ui/src/app.rs
@@ -71,6 +71,8 @@ pub struct VsTermApp {
     bottom: BottomPanelState,
     status: String,
     last_term_size: (u16, u16),
+    /// After a successful connect, grab keyboard focus on the terminal grid once.
+    focus_terminal: bool,
     locale: Locale,
     /// Connect / reconnect motion preference (trail / shatter / off).
     connect_fx: ConnectFxMode,
@@ -172,6 +174,7 @@ impl VsTermApp {
             bottom: BottomPanelState::default(),
             status,
             last_term_size: (80, 24),
+            focus_terminal: false,
             locale,
             connect_fx,
             pending_connect: None,
@@ -264,6 +267,8 @@ impl VsTermApp {
                 self.left_tab = LeftTab::Monitor;
                 self.main_tab = MainTab::Terminal;
                 self.sync_host_binding();
+                self.last_term_size = (0, 0);
+                self.focus_terminal = true;
             }
             Err(err) => {
                 self.error_dialog = Some(format_conn_error(&err));
@@ -474,6 +479,9 @@ impl VsTermApp {
         let config_for_thread = config.clone();
         let config_for_pending = config.clone();
         let replace_for_thread = replace_id;
+        // Open the PTY near the current pane size so the first paint does not
+        // leave a tall black band under a leftover 80×24 grid.
+        let (open_cols, open_rows) = self.preferred_term_size();
         std::thread::Builder::new()
             .name("vsterm-ssh-connect".into())
             .spawn(move || {
@@ -494,8 +502,8 @@ impl VsTermApp {
                         &config,
                         vault.as_ref(),
                         interactive_password,
-                        80,
-                        24,
+                        open_cols,
+                        open_rows,
                     )
                     .await
                 });
@@ -578,6 +586,10 @@ impl VsTermApp {
                 self.status = i18n::t("status.connected");
                 // Remember username (and key path) typed at the login prompt.
                 self.persist_connect_identity(&pending.config);
+                // Force a PTY resize against the real pane on the next paint, and
+                // put keyboard focus in the terminal so typing works immediately.
+                self.last_term_size = (0, 0);
+                self.focus_terminal = true;
                 if let Some(rect) = self.last_auth_dialog_rect.take() {
                     let accent = crate::fx::accent_from_tag(pending.config.color_tag.as_deref());
                     match self.connect_fx {
@@ -866,6 +878,16 @@ impl VsTermApp {
                 tracing::debug!("persist connect identity {}: {err}", connected.id);
             }
         }
+    }
+
+    /// Best-effort PTY size for a new SSH shell (last paint, or last known size).
+    fn preferred_term_size(&self) -> (u16, u16) {
+        if let Some(rect) = self.last_central_rect.filter(|r| r.width() > 40.0 && r.height() > 40.0)
+        {
+            return TerminalView::size_for_rect(rect.size());
+        }
+        let (c, r) = self.last_term_size;
+        (c.max(20), r.max(5))
     }
 
     fn persist_session_editor(&mut self, mut state: SessionEditorState) {
@@ -1883,8 +1905,24 @@ impl eframe::App for VsTermApp {
 
                     ui.allocate_ui_at_rect(term_rect, |ui| {
                         ui.set_clip_rect(term_rect);
-                        let (cols, rows) = TerminalView::show(ui, &self.connections);
-                        if (cols, rows) != self.last_term_size && cols > 0 && rows > 0 {
+                        // Wait out connect FX / auth chrome so focus is not stolen back.
+                        let grab = self.focus_terminal
+                            && self.auth_prompt.is_none()
+                            && !self.fx.is_active();
+                        let (cols, rows) =
+                            TerminalView::show(ui, &self.connections, grab);
+                        if grab {
+                            self.focus_terminal = false;
+                        }
+                        // Sync against the live emulator size, not only the last
+                        // UI request — after connect the PTY may still be 80×24
+                        // while last_term_size already matches the pane.
+                        let actual = self.connections.active_terminal_size();
+                        let need_resize = cols > 0
+                            && rows > 0
+                            && (actual != Some((cols, rows))
+                                || (cols, rows) != self.last_term_size);
+                        if need_resize {
                             if let Err(err) = self.connections.resize_active(cols, rows) {
                                 tracing::debug!("resize: {err}");
                             } else {

--- a/crates/app-ui/src/terminal_view.rs
+++ b/crates/app-ui/src/terminal_view.rs
@@ -82,15 +82,25 @@ impl TermSelection {
 pub struct TerminalView;
 
 impl TerminalView {
+    /// Estimate PTY cols/rows for a terminal pane of `size` (includes gutter + scrollbar).
+    pub fn size_for_rect(size: egui::Vec2) -> (u16, u16) {
+        let content_w = (size.x - SCROLL_W - GUTTER_W).max(CELL_W * 20.0);
+        let cols = ((content_w / CELL_W).floor() as u16).max(20);
+        let rows = ((size.y / CELL_H).floor() as u16).max(5);
+        (cols, rows)
+    }
+
     /// Renders the active terminal. Returns desired (cols, rows) based on available space.
-    pub fn show(ui: &mut Ui, mgr: &Arc<ConnectionManager>) -> (u16, u16) {
+    ///
+    /// When `grab_focus` is true, keyboard focus moves to the terminal grid so the
+    /// user can type immediately after connect.
+    pub fn show(ui: &mut Ui, mgr: &Arc<ConnectionManager>, grab_focus: bool) -> (u16, u16) {
         // Stay strictly inside the parent-allocated rect (no bleed into bottom strip).
         let outer_max = ui.max_rect();
         ui.set_clip_rect(outer_max);
         let avail = ui.available_size().min(outer_max.size());
         let content_w = (avail.x - SCROLL_W - GUTTER_W).max(CELL_W * 20.0);
-        let cols = ((content_w / CELL_W).floor() as u16).max(20);
-        let rows = ((avail.y / CELL_H).floor() as u16).max(5);
+        let (cols, rows) = Self::size_for_rect(avail);
 
         let (outer, _) = ui.allocate_exact_size(avail, Sense::hover());
         let outer = outer.intersect(outer_max);
@@ -301,13 +311,13 @@ impl TerminalView {
                 .rect_filled(scroll_rect, 0.0, Color32::from_rgb(20, 20, 22));
         }
 
-        if resp.clicked_by(PointerButton::Primary) {
+        if grab_focus || resp.clicked_by(PointerButton::Primary) {
             resp.request_focus();
         }
 
         // Hovering the grid claims keyboard focus so Space/Enter go to the PTY,
         // not leftover-focused chrome buttons (quick commands, toolbar, …).
-        if !menu_open && resp.hovered() && !resp.has_focus() {
+        if !menu_open && !grab_focus && resp.hovered() && !resp.has_focus() {
             resp.request_focus();
         }
 

--- a/crates/connection-mgr/src/manager.rs
+++ b/crates/connection-mgr/src/manager.rs
@@ -558,6 +558,17 @@ impl ConnectionManager {
         conn.resize(cols, rows)
     }
 
+    /// Grid size of the active terminal emulator, if any.
+    pub fn active_terminal_size(&self) -> Option<(u16, u16)> {
+        let id = self.active_id()?;
+        let conns = self.connections.lock();
+        let conn = conns.get(&id)?;
+        if conn.state != ConnectionState::Connected {
+            return None;
+        }
+        Some(conn.terminal.size())
+    }
+
     /// Drop dead connections (SSH process exited). Keep the tab for reconnect.
     pub fn reap_dead(&self) {
         let dead: Vec<ConnectionId> = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题
1. 登录成功后键盘焦点不在终端，不能直接敲命令。  
2. 首次进入终端时底部有一块黑边，滚动可见；拖拽窗口缩放后消失——PTY 仍停在初始尺寸（常为 80×24），未与窗格对齐。

## 修复
- 连接成功后（动画结束后）把焦点交给终端网格  
- 建连时用当前窗格估算的 cols/rows，而不是固定 80×24  
- 每帧按**实际 emulator 尺寸**与窗格对比并 resize（避免 `last_term_size` 已匹配却未同步 PTY）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9e2800f-61d1-4baa-a3f3-c15665d58d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9e2800f-61d1-4baa-a3f3-c15665d58d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

